### PR TITLE
Working branch for running noop pipeline of build-definitions

### DIFF
--- a/ckcp/docker/ckcp/entry.sh
+++ b/ckcp/docker/ckcp/entry.sh
@@ -6,4 +6,4 @@ rm -rf .kcp/
   --pull-mode=false \
   --run-controllers \
   --auto-publish-apis \
-  --resources-to-sync="deployments.apps,pods,services,secrets"
+  --resources-to-sync="deployments.apps,statefulsets.apps,pods,services,secrets,persistentvolumeclaims"

--- a/ckcp/run.sh
+++ b/ckcp/run.sh
@@ -80,6 +80,9 @@ else
 
         # Conversion is not working yet on KCP
         (cd pipeline && git apply ../../remove-conversion.patch)
+
+        # Enable OCI bundles
+        (cd pipeline && git apply ../../oci-bundle.patch)
       fi
 
       #clean up old pods if any in kcp--admin--default ns

--- a/ckcp/run.sh
+++ b/ckcp/run.sh
@@ -83,6 +83,9 @@ else
 
         # Enable OCI bundles
         (cd pipeline && git apply ../../oci-bundle.patch)
+
+        # Enable artifact PVC volume
+        (cd pipeline && git apply ../../pvc.patch)
       fi
 
       #clean up old pods if any in kcp--admin--default ns

--- a/local/run.sh
+++ b/local/run.sh
@@ -28,6 +28,9 @@ then
 
   # Enable OCI bundles
   (cd pipeline && git apply "$ROOT_DIR/oci-bundle.patch")
+
+  # Enable artifact PVC volume
+  (cd pipeline && git apply "$ROOT_DIR/pvc.patch")
 fi
 if [[ ! -d ./triggers ]]
 then

--- a/local/run.sh
+++ b/local/run.sh
@@ -63,7 +63,7 @@ rm -rf .kcp/
   --pull-mode=false \
   --run-controllers \
   --auto-publish-apis \
-  --resources-to-sync="deployments.apps,pods,services,secrets" &
+  --resources-to-sync="deployments.apps,statefulsets.apps,pods,services,secrets,persistentvolumeclaims" &
 KCP_PID=$!
 
 export KUBECONFIG="$(pwd)/.kcp/admin.kubeconfig"

--- a/local/run.sh
+++ b/local/run.sh
@@ -25,6 +25,9 @@ then
 
   # Conversion is not working yet on KCP
   (cd pipeline && git apply "$ROOT_DIR/remove-conversion.patch")
+
+  # Enable OCI bundles
+  (cd pipeline && git apply "$ROOT_DIR/oci-bundle.patch")
 fi
 if [[ ! -d ./triggers ]]
 then

--- a/oci-bundle.patch
+++ b/oci-bundle.patch
@@ -1,0 +1,13 @@
+diff --git a/config/config-feature-flags.yaml b/config/config-feature-flags.yaml
+index 870ceadd4..fb2d2e75b 100644
+--- a/config/config-feature-flags.yaml
++++ b/config/config-feature-flags.yaml
+@@ -73,7 +73,7 @@ data:
+   # Setting this flag to "true" enables the use of Tekton OCI bundle.
+   # This is an experimental feature and thus should still be considered
+   # an alpha feature.
+-  enable-tekton-oci-bundles: "false"
++  enable-tekton-oci-bundles: "true"
+   # Setting this flag to "true" enables the use of custom tasks from
+   # within pipelines.
+   # This is an experimental feature and thus should still be considered

--- a/pvc.patch
+++ b/pvc.patch
@@ -1,0 +1,16 @@
+diff --git a/config/config-artifact-pvc.yaml b/config/config-artifact-pvc.yaml
+index f3ca3b1c0..337559392 100644
+--- a/config/config-artifact-pvc.yaml
++++ b/config/config-artifact-pvc.yaml
+@@ -20,9 +20,5 @@ metadata:
+   labels:
+     app.kubernetes.io/instance: default
+     app.kubernetes.io/part-of: tekton-pipelines
+-# data:
+-#   # size of the PVC volume
+-#   size: 5Gi
+-#
+-#   # storage class of the PVC volume
+-#   storageClassName: storage-class-name
++data:
++  size: 5Gi


### PR DESCRIPTION
1. Checkout this PR and deploy KCP+Pipelines in Kubernetes with `./run.sh pipelines`
2. Checkout infra-deployments
3. Edit `hack/build/build.sh` to use `BUNDLE=quay.io/mkovarik/build-templates-bundle:noop-utils`
4. Run `./hack/build/quick-noop-build.sh` with kubeconfig pointing to KCP.


Output:

```
$ k get prs,trs,pods
NAME                                            SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
pipelinerun.tekton.dev/noop-2022-02-17-094347   True        Succeeded   2m24s       82s

NAME                                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
taskrun.tekton.dev/noop-2022-02-17-094347-merge   True        Succeeded   88s         82s
taskrun.tekton.dev/noop-2022-02-17-094347-start   True        Succeeded   2m14s       105s
taskrun.tekton.dev/noop-2022-02-17-094347-task1   True        Succeeded   104s        97s
taskrun.tekton.dev/noop-2022-02-17-094347-task2   True        Succeeded   104s        97s
taskrun.tekton.dev/noop-2022-02-17-094347-task3   True        Succeeded   96s         89s

NAME                                   READY   STATUS      RESTARTS   AGE
pod/noop-2022-02-17-094347-merge-pod   0/1     Completed   0          88s
pod/noop-2022-02-17-094347-start-pod   0/1     Completed   0          2m14s
pod/noop-2022-02-17-094347-task1-pod   0/1     Completed   0          104s
pod/noop-2022-02-17-094347-task2-pod   0/1     Completed   0          104s
pod/noop-2022-02-17-094347-task3-pod   0/1     Completed   0          96s

$ k api-resources 
NAME                          SHORTNAMES   APIVERSION                             NAMESPACED   KIND
configmaps                    cm           v1                                     true         ConfigMap
events                        ev           v1                                     true         Event
limitranges                   limits       v1                                     true         LimitRange
namespaces                    ns           v1                                     false        Namespace
persistentvolumeclaims        pvc          v1                                     true         PersistentVolumeClaim
pods                          po           v1                                     true         Pod
resourcequotas                quota        v1                                     true         ResourceQuota
secrets                                    v1                                     true         Secret
serviceaccounts               sa           v1                                     true         ServiceAccount
services                      svc          v1                                     true         Service
customresourcedefinitions     crd,crds     apiextensions.k8s.io/v1                false        CustomResourceDefinition
apiresourceimports                         apiresource.kcp.dev/v1alpha1           false        APIResourceImport
negotiatedapiresources                     apiresource.kcp.dev/v1alpha1           false        NegotiatedAPIResource
deployments                   deploy       apps/v1                                true         Deployment
statefulsets                  sts          apps/v1                                true         StatefulSet
tokenreviews                               authentication.k8s.io/v1               false        TokenReview
localsubjectaccessreviews                  authorization.k8s.io/v1                true         LocalSubjectAccessReview
selfsubjectaccessreviews                   authorization.k8s.io/v1                false        SelfSubjectAccessReview
selfsubjectrulesreviews                    authorization.k8s.io/v1                false        SelfSubjectRulesReview
subjectaccessreviews                       authorization.k8s.io/v1                false        SubjectAccessReview
certificatesigningrequests    csr          certificates.k8s.io/v1                 false        CertificateSigningRequest
clusters                                   cluster.example.dev/v1alpha1           false        Cluster
leases                                     coordination.k8s.io/v1                 true         Lease
events                        ev           events.k8s.io/v1                       true         Event
flowschemas                                flowcontrol.apiserver.k8s.io/v1beta1   false        FlowSchema
prioritylevelconfigurations                flowcontrol.apiserver.k8s.io/v1beta1   false        PriorityLevelConfiguration
clusterrolebindings                        rbac.authorization.k8s.io/v1           false        ClusterRoleBinding
clusterroles                               rbac.authorization.k8s.io/v1           false        ClusterRole
rolebindings                               rbac.authorization.k8s.io/v1           true         RoleBinding
roles                                      rbac.authorization.k8s.io/v1           true         Role
conditions                                 tekton.dev/v1alpha1                    true         Condition
pipelineresources                          tekton.dev/v1alpha1                    true         PipelineResource
pipelineruns                  pr,prs       tekton.dev/v1beta1                     true         PipelineRun
runs                                       tekton.dev/v1alpha1                    true         Run
taskruns                      tr,trs       tekton.dev/v1beta1                     true         TaskRun
workspaces                                 tenancy.kcp.dev/v1alpha1               false        Workspace
workspaceshards                            tenancy.kcp.dev/v1alpha1               false        WorkspaceShard
```