### PR TITLE
development: Use Rootless Podman

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,10 +21,11 @@ Prerequisites:
 ```
 
 ---
-**_NOTE:_**
+**_NOTES:_**
 
 1. Podman is used per default as container engine if available on the machine. If both podman and docker are available it is possible to force the use of docker by setting an environment variable `CONTAINER_ENGINE=docker`.
-2. Podman defaults to running as sudo (root). To run podman in rootless mode, use the environment variable `ALLOW_ROOTLESS=true`.
+2. Podman defaults to running as sudo (root). To run podman in rootless mode, use the environment variable `ALLOW_ROOTLESS=true`. See the [kind documentation](https://kind.sigs.k8s.io/docs/user/rootless/) for the prerequisites.
+ 
 ---
 
 ## kcp cluster

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,8 +21,10 @@ Prerequisites:
 ```
 
 ---
-**_NOTE:_**  podman is used per default as container engine if available on the machine. If both podman and docker are available it is possible to force the use of docker by setting an environment variable `CONTAINER_ENGINE=docker`.
+**_NOTE:_**
 
+1. Podman is used per default as container engine if available on the machine. If both podman and docker are available it is possible to force the use of docker by setting an environment variable `CONTAINER_ENGINE=docker`.
+2. Podman defaults to running as sudo (root). To run podman in rootless mode, use the environment variable `ALLOW_ROOTLESS=true`.
 ---
 
 ## kcp cluster

--- a/ckcp/README.MD
+++ b/ckcp/README.MD
@@ -29,7 +29,8 @@ Long Version:
 Before you execute the script, 
 
 1. You need to have a kubernetes/openshift cluster.
-2. You need to build the docker image for ckcp and upload it to *quay.io* and make it *Public*.
+2. You need to build the docker image for ckcp and upload it to a container registry that is accessible from your clusters.
+   Pushing to your account on *quay.io* and making the image *Public* is recommended.
 3. You need to install [oc](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html)
 4. You need to install [argocd](https://argo-cd.readthedocs.io/en/stable/cli_installation/).
 5. You need to install [yq](http://mikefarah.github.io/yq/#install)

--- a/ckcp/build.sh
+++ b/ckcp/build.sh
@@ -2,6 +2,15 @@
 
 set -exuo pipefail
 
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+pushd "$parent_path"
+
+source ../local/.utils
+
+detect_container_engine
+
 IMAGE="$KO_DOCKER_REPO/ckcp:986710c754ed0dac9ae1525661de931e5dd7c0cc"
-docker build -t "$IMAGE" docker/ckcp/
-docker push "$IMAGE"
+${CONTAINER_ENGINE} build -t "$IMAGE" docker/ckcp/
+${CONTAINER_ENGINE} push "$IMAGE"
+
+popd

--- a/ckcp/docker/ckcp/Dockerfile
+++ b/ckcp/docker/ckcp/Dockerfile
@@ -1,5 +1,5 @@
 #use golang as base image and compile kcp
-FROM golang:1.17 as src
+FROM docker.io/golang:1.17 as src
 
 WORKDIR /go/src/app
 RUN git clone https://github.com/kcp-dev/kcp.git && cd ./kcp && git checkout 986710c754ed0dac9ae1525661de931e5dd7c0cc
@@ -7,7 +7,7 @@ RUN git clone https://github.com/kcp-dev/kcp.git && cd ./kcp && git checkout 986
 WORKDIR /go/src/app/kcp
 RUN go build -ldflags "-X k8s.io/component-base/version.gitVersion=v1.22.2 -X k8s.io/component-base/version.gitCommit=5e58841cce77d4bc13713ad2b91fa0d961e69192" -o bin/kcp ./cmd/kcp
 
-FROM fedora:latest
+FROM docker.io/fedora:latest
 
 WORKDIR /workspace
 #copy the golang compiled kcp application from the src builder to our main docker image

--- a/local/.utils
+++ b/local/.utils
@@ -44,10 +44,14 @@ setupTraps() {
 
 detect_container_engine() {
     CONTAINER_ENGINE="${CONTAINER_ENGINE:-}"
+    ALLOW_ROOTLESS="${ALLOW_ROOTLESS:-false}"
     if [[ -n "${CONTAINER_ENGINE}" ]]; then
       return
     fi
     CONTAINER_ENGINE="sudo podman"
+    if [[ "${ALLOW_ROOTLESS}" == "true" ]]; then
+        CONTAINER_ENGINE=podman
+    fi
     if ! command -v podman; then
         CONTAINER_ENGINE=docker
         return


### PR DESCRIPTION
- Use ALLOW_ROOTLESS environment variable to enable rootless podman.
- Update detect_container_engine to run rootless podman if desired.
- Use detect_container_engine function in building ckcp image.
- Use docker.io image references in ckcp Dockerfile.

Signed-off-by: Adam Kaplan <adam.kaplan@redhat.com>