### PR TITLE
Document inotify issue deploying ingress

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,3 +88,18 @@ Files in /tmp are usually cleared by reboot and depending on the operating syste
 
 Workload clusters created with kind can be removed with the usual kind command for the purpose `kind delete clusters us-east1 us-west1`
 Files for the kind clusters are stored in a directory located in /tmp as well if `$TMPDIR` has not been set to another location.
+
+## Troubleshooting
+
+### Ingress router pods crashloop - "too many open files"
+
+Depending on your machine's configuration, the ingress router and ArgoCD pods may crashloop with a "too many open files" error.
+This is likely due to the Linux kernel limiting the number of file watches.
+
+On Fedora, this can be fixed by adding a `.conf` file to `/etc/sysctl.d/ increasing the number of file watches and instances:
+
+```sh
+# /etc/sysctl.d/98_fs_inotify_increase_watches.conf
+fs.inotify.max_user_watches=2097152
+fs.inotify.max_user_instances=256
+```

--- a/local/kind/setup.sh
+++ b/local/kind/setup.sh
@@ -19,26 +19,25 @@ set -o nounset
 set -o pipefail
 
 prechecks () {
-  if ! command -v kind &> /dev/null
-  then
-    printf "Kind could not be found\n"
-    exit 1
-  fi
+    if ! command -v kind &> /dev/null; then
+        printf "Kind could not be found\n"
+        exit 1
+    fi
 
-  if [[ ${ALLOW_ROOTLESS} == "true" ]]; then
-    echo "Rootless mode enabled"
-  fi
+    if [[ "${ALLOW_ROOTLESS}" == "true" ]]; then
+        echo "Rootless mode enabled"
+    fi
 
-  if [[ "${CONTAINER_ENGINE}" != "docker" && "${ALLOW_ROOTLESS}" != "true" ]]; then
-    KIND_CMD="sudo kind"
-  else
-    KIND_CMD="kind"
-  fi
+    if [[ "${CONTAINER_ENGINE}" != "docker" && "${ALLOW_ROOTLESS}" != "true" ]]; then
+        KIND_CMD="sudo kind"
+    else
+        KIND_CMD="kind"
+    fi
 }
 
 mk_tmpdir () {
-  TMP_DIR="$(mktemp -d -t kind-pipelines-service.XXXXXXXXX)"
-  printf "Temporary directory created: %s\n" "${TMP_DIR}"
+    TMP_DIR="$(mktemp -d -t kind-pipelines-service.XXXXXXXXX)"
+    printf "Temporary directory created: %s\n" "${TMP_DIR}"
 }
 
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
@@ -79,12 +78,12 @@ for cluster in "${CLUSTERS[@]}"; do
             --config "${TMP_DIR}/${cluster}.config" \
             --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig"
 
-	if [[  ${KIND_CMD} == "sudo kind" ]]; then
-		sudo chmod +r "${TMP_DIR}/${cluster}.kubeconfig"
-	fi
+        if [[ ${KIND_CMD} == "sudo kind" ]]; then
+            sudo chmod +r "${TMP_DIR}/${cluster}.kubeconfig"
+        fi
 
-	printf "Provisioning ingress router in %s\n" "${cluster}"
-	kubectl --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig" apply -f ingress-router.yaml
+        printf "Provisioning ingress router in %s\n" "${cluster}"
+        kubectl --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig" apply -f ingress-router.yaml
     fi
 
     if [[ ! -f "${TMP_DIR}/${cluster}.yaml" ]]; then
@@ -97,7 +96,7 @@ done
 
 NO_ARGOCD="${NO_ARGOCD:-}"
 if [[ $(tr '[:upper:]' '[:lower:]' <<< "$NO_ARGOCD") != "true" ]]; then
-	KUBECONFIG="${TMP_DIR}/${CLUSTERS[0]}.kubeconfig" ../argocd/setup.sh
+    KUBECONFIG="${TMP_DIR}/${CLUSTERS[0]}.kubeconfig" ../argocd/setup.sh
 fi
 
 popd


### PR DESCRIPTION
Ingress deployments on the local kind clusters can fail due to the
kernel limiting the number of file watch instances. This can be fixed by increasing
the number of file watches and instances for the machine.

Signed-off-by: Adam Kaplan <adam.kaplan@redhat.com>