### PR TITLE
Pipelines as Code: installation and repository registration

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  description = "Allowlist"
+  paths = [
+    '''gitops/pac/README.md''',
+  ]

--- a/gitops/pac/README.md
+++ b/gitops/pac/README.md
@@ -1,0 +1,40 @@
+# Pipelines as Code
+
+## Goal
+
+[Pipelines as Code](https://pipelinesascode.com/) can be leveraged for automating the registration of new clusters to Argo CD and kcp following a GitOps approach.
+When a kubeconfig file gets added to a GitOps repository Pipelines as Code triggers a pipeline for the purpose. It is similar in this respect to GitHub actions and a git provider independent alternative to it.
+
+---
+**_NOTE:_**  Pipelines as Code can leverage any cluster for running its pipelines. The cluster does not have to be part of the Pipelines Service infrastructure.
+
+---
+
+## Instalation and runner registration
+
+This directory contains the manifests used for installing Pipelines as Code and registering the runners.
+
+Pipelines as Code comes pre-installed with the OpenShit Pipelines Operator. This is what should be used for its [installation on OpenShift](https://docs.openshift.com/container-platform/4.10/cicd/pipelines/installing-pipelines.html).
+The runner registration still needs to be done if it hasn't already.
+
+A webhook and credentials need to be added on the provider side of the git repository. Follow the [Pipelines as Code instructions](https://pipelinesascode.com/docs/install/) specific to your provider for the purpose. 
+
+A script has been made available in this directory for automating the cluster (runner) side. It accepts the following parameters:
+
+- KUBECONFIG: the path to the kubeconfig file used to connect to the cluster where Pipelines as Code will be installed
+- GITOPS_REPO: the repository for which Pipelines as Code needs to be set up
+- GIT_TOKEN: personal access token to the git repository
+- WEBHOOK_SECRET: secret configured on the webhook used to validate the payload
+- CONTROLLER_INSTALL (optional): the controller will be installed only if it is set to true. Pipelines as Code are installed together with the OpenShift Pipelines operator
+- PAC_HOST (optional): Hostname for the Pipelines as Code ingress if CONTROLLER_INSTALL=true has been set
+
+
+The registration can be performed by running for instance:
+
+```console
+KUBECONFIG="/pathto/kubeconfig" GITOPS_REPO="https://gitops.org.com/org/pipelines-service-infra" GIT_TOKEN="s2sdfdsf3EFfd42fFSfsg4ds" WEBHOOK_SECRET="b3erewer43a44eerwsafdfasf11cd37" ./setup.sh
+```
+
+## Pipelines
+
+A pipeline for the registration of new clusters to ArgoCD and kcp will shortly be made available.

--- a/gitops/pac/manifests/ci-runner-ns.yaml
+++ b/gitops/pac/manifests/ci-runner-ns.yaml
@@ -1,0 +1,9 @@
+# This file defines the namespace where the ci-runners get spawned
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ci-runner
+  labels:
+    app.kubernetes.io/name: ci-runner
+    kubernetes.io/metadata.name: ci-runner
+

--- a/gitops/pac/manifests/ingress.yaml
+++ b/gitops/pac/manifests/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    pipelines-as-code/route: controller
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: pipelines-as-code
+  namespace: pipelines-as-code
+spec:
+  rules:
+  - host: webhook-pipelines-as-code.apps.127.0.0.1.nip.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: pipelines-as-code-controller
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+

--- a/gitops/pac/manifests/kustomization.yaml
+++ b/gitops/pac/manifests/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ci-runner-ns.yaml
+- repository.yaml
+- webhook-cfg-secret.yaml

--- a/gitops/pac/manifests/repository.yaml
+++ b/gitops/pac/manifests/repository.yaml
@@ -1,0 +1,17 @@
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: gitops-repo
+  namespace: ci-runner
+spec:
+  url: "https://gitops.com/group/project"
+  git_provider:
+    secret:
+      name: "gitops-webhook-config"
+      # Set this if you have a different key in your secret
+      # key: "provider.token"
+    webhook_secret:
+      name: "gitops-webhook-config"
+      # Set this if you have a different key in your secret
+      # key: "webhook.secret"
+

--- a/gitops/pac/manifests/webhook-cfg-secret.yaml
+++ b/gitops/pac/manifests/webhook-cfg-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  provider.token: XXXXXXXXXXXXXXXXXXXXXXX=
+  webhook.secret: YYYYYYYYYYYYYYYYYYYYYYYYY==
+kind: Secret
+metadata:
+  name: gitops-webhook-config
+  namespace: ci-runner
+type: Opaque

--- a/gitops/pac/setup.sh
+++ b/gitops/pac/setup.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The pipelines-service Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+
+    printf "Usage: KUBECONFIG="path-to-kubeconfig" GITOPS_REPO="https://gitops.com/group/project" GIT_TOKEN="XXXXXXXXX" WEBHOOK_SECRET="YYYYYYYYYY" ./setup.sh\n\n"
+	
+    # Parameters
+    printf "The following parameters need to be passed to the script:\n"
+    printf "KUBECONFIG: the path to the kubeconfig file used to connect to the cluster where Pipelines as Code will be installed\n"
+    printf "GITOPS_REPO: the repository for which Pipelines as Code needs to be set up\n"
+    printf "GIT_TOKEN: personal access token to the git repository\n"
+    printf "WEBHOOK_SECRET: secret configured on the webhook used to validate the payload\n"
+    printf "CONTROLLER_INSTALL (optional): the controller will be installed only if it is set to true. Pipelines as Code are installed together with the OpenShift Pipelines operator\n"
+    printf "PAC_HOST (optional): Hostname for the Pipelines as Code ingress if CONTROLLER_INSTALL=true has been set\n\n"
+}
+
+check_params() {
+    KUBECONFIG="${KUBECONFIG:-}"
+    GITOPS_REPO="${GITOPS_REPO:-}"
+    GIT_TOKEN="${GIT_TOKEN:-}"
+    WEBHOOK_SECRET="${WEBHOOK_SECRET:-}"
+    if [[ -z "${KUBECONFIG}" ]]; then
+        printf "KUBECONFIG environment variable needs to be set\n\n"
+	usage
+	exit 1
+    fi
+    if [[ -z "${GITOPS_REPO}" ]]; then
+        printf "GITOPS_REPO environment variable needs to be set\n\n"
+	usage
+        exit 1
+    fi
+    if [[ -z "${GIT_TOKEN}" ]]; then
+        printf "GIT_TOKEN environment variable needs to be set\n\n"
+        usage
+        exit 1
+    fi
+    if [[ -z "${WEBHOOK_SECRET}" ]]; then
+        printf "WEBHOOK_SECRET environment variable needs to be set\n\n"
+        usage
+        exit 1
+    fi
+}
+
+controller_install() {
+    CONTROLLER_INSTALL="${CONTROLLER_INSTALL:-}"
+    if [[ $(tr '[:upper:]' '[:lower:]' <<< "$CONTROLLER_INSTALL") == "true" ]]; then
+        printf "Installing controller\n"
+       kubectl --kubeconfig ${KUBECONFIG} apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.k8s.yaml
+    fi
+}
+
+mk_tmpdir () {
+  TMP_DIR="$(mktemp -d -t pac-pipelines-service.XXXXXXXXX)"
+  printf "Temporary directory created: ${TMP_DIR}\n"
+}
+
+kustomize () {
+
+    GIT_TOKEN=$(echo "${GIT_TOKEN}" | base64)
+    WEBHOOK_SECRET=$(echo "${WEBHOOK_SECRET}" | base64)
+
+    # Create a json patch for the repository
+    cat <<EOF > ${TMP_DIR}/patch-repo.yaml
+- op: replace
+  path: /spec/url
+  value: ${GITOPS_REPO}
+EOF
+
+    # Create a json patch for the secret
+    cat <<EOF > ${TMP_DIR}/patch-secret.yaml
+- op: replace
+  path: /data/provider.token
+  value: ${GIT_TOKEN}
+- op: replace
+  path: /data/webhook.secret
+  value: ${WEBHOOK_SECRET}
+EOF
+
+    if [[ $(tr '[:upper:]' '[:lower:]' <<< "$CONTROLLER_INSTALL") == "true" ]]; then
+        # Create a json patch for the ingress
+        cat <<EOF > ${TMP_DIR}/patch-ingress.yaml
+- op: replace
+  path: /spec/rules/0/host
+  value: ${PAC_HOST}
+EOF
+        cp $parent_path/manifests/ingress.yaml ${TMP_DIR}/ingress.yaml
+        # kustomization.yaml
+        cat <<EOF > ${TMP_DIR}/kustomization.yaml
+resources:
+- ingress.yaml
+- ../../$parent_path/manifests
+patchesJson6902:
+- target:
+    group: pipelinesascode.tekton.dev
+    version: v1alpha1
+    kind: Repository
+    name: gitops-repo
+  path: patch-repo.yaml
+- target:
+    version: v1
+    kind: Secret
+    name: gitops-webhook-config
+  path: patch-secret.yaml
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+    name: pipelines-as-code
+  path: patch-ingress.yaml
+EOF
+
+    else
+	# kustomization.yaml
+        cat <<EOF > ${TMP_DIR}/kustomization.yaml
+resources:
+- ../../$parent_path/manifests
+patchesJson6902:
+- target:
+    group: pipelinesascode.tekton.dev
+    version: v1alpha1
+    kind: Repository
+    name: gitops-repo
+  path: patch-repo.yaml
+- target:
+    version: v1
+    kind: Secret
+    name: gitops-webhook-config
+  path: patch-secret.yaml
+EOF
+
+    fi
+    kubectl kustomize ${TMP_DIR} > ${TMP_DIR}/patched.yaml
+    kubectl --kubeconfig=${KUBECONFIG} apply -f ${TMP_DIR}/patched.yaml
+}
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+printf "Installing Pipelines as Code\n"
+
+check_params
+controller_install
+mk_tmpdir
+
+# Build kustomization and apply to cluster
+kustomize
+
+printf "Pipelines as Code installed\n"
+


### PR DESCRIPTION
Add manifests, a script and instructions for the installation of Pipelines as Code and the registration of repositories.

Goal:
Pipelines as Code can be leveraged for automating the registration of clusters to Argo CD and kcp when their kubeconfig file gets added to a git repository, following a GitOps approach.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>