### PR TITLE
fix: update local & ckcp scripts, fix MacOS compat.

### DIFF
--- a/ckcp/README.MD
+++ b/ckcp/README.MD
@@ -33,7 +33,7 @@ Before you execute the script,
    Pushing to your account on *quay.io* and making the image *Public* is recommended.
 3. You need to install [oc](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html)
 4. You need to install [argocd](https://argo-cd.readthedocs.io/en/stable/cli_installation/).
-5. You need to install [yq](http://mikefarah.github.io/yq/#install)
+5. You need to install [yq](https://mikefarah.gitbook.io/yq/#install)
 
 Note: KO_DOCKER_REPO has to point to your own *quay.io* repo.
 ```

--- a/ckcp/gitops.sh
+++ b/ckcp/gitops.sh
@@ -44,10 +44,7 @@ parse_args() {
   local trigger_list="triggers_crds triggers_interceptors triggers_controller"
   APP_LIST="$default_list"
 
-  local args
-  args="$(getopt -o dha: -l "debug,help,app,all" -n "$0" -- "$@")"
-  eval set -- "$args"
-  while true; do
+  while [[ $# -gt 0 ]]; do
     case $1 in
     -a | --app)
       shift
@@ -143,7 +140,7 @@ install_openshift_gitops() {
   # Log into ArgoCD
   echo -n "  - ArgoCD Login: "
   local argocd_password
-  argocd_password="$(oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath="{.data.admin\.password}" | base64 --decode --ignore-garbage)"
+  argocd_password="$(oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath="{.data.admin\.password}" | base64 --decode)"
   argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --username admin --password "$argocd_password" >/dev/null
   echo "OK"
 
@@ -151,7 +148,7 @@ install_openshift_gitops() {
   local cluster_name="plnsvc"
   echo -n "  - Register host cluster to ArgoCD as '$cluster_name': "
   if ! KUBECONFIG="$KUBECONFIG_MERGED" argocd cluster get "$cluster_name" >/dev/null 2>&1; then
-    argocd cluster add "$(cat "$KUBECONFIG" | yq ".current-context")" --name="$cluster_name" --upsert --yes >/dev/null 2>&1
+    argocd cluster add "$(yq e ".current-context" "$KUBECONFIG")" --name="$cluster_name" --upsert --yes >/dev/null 2>&1
   fi
   echo "OK"
 }
@@ -171,7 +168,7 @@ install_ckcp() {
   # Post install
   #############################################################################
   # Copy the kubeconfig of kcp from inside the pod onto the local filesystem
-  podname="$(oc get pods --ignore-not-found -n "$ns" -l=app=kcp-in-a-pod -o jsonpath={.items[0].metadata.name})"
+  podname="$(oc get pods --ignore-not-found -n "$ns" -l=app=kcp-in-a-pod -o jsonpath='{.items[0].metadata.name}')"
   oc cp "$APP/$podname:/workspace/.kcp/admin.kubeconfig" "$KUBECONFIG_KCP" >/dev/null
 
   # Check if external ip is assigned and replace kcp's external IP in the kubeconfig file
@@ -179,7 +176,7 @@ install_ckcp() {
   if grep -q "localhost" "$KUBECONFIG_KCP"; then
     local route
     route="$(oc get route ckcp -n "$APP" -o jsonpath='{.spec.host}')"
-    sed -i "s/localhost:6443/$route:443/g" "$KUBECONFIG_KCP"
+    yq e -i "(.clusters[].cluster.server) |= sub(\"localhost:6443\", \"$route:443\")" "$KUBECONFIG_KCP"
   fi
   echo "OK"
 
@@ -229,9 +226,9 @@ metadata:
     kubernetes.io/service-account.name: $argocd_sa
 type: kubernetes.io/service-account-token
 data:
-  ca.crt: $(cat "$KUBECONFIG_KCP" | yq ".clusters.[0].cluster.certificate-authority-data")
+  ca.crt: $(yq e ".clusters.[0].cluster.certificate-authority-data" "$KUBECONFIG_KCP")
   namespace: $(echo "$argocd_ns" | base64)
-  token: $(cat "$KUBECONFIG_KCP" | yq ".users.[0].user.token" | tr -d '\n' | base64)
+  token: $(yq e ".users.[0].user.token" "$KUBECONFIG_KCP" | tr -d '\n' | base64)
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -245,7 +242,7 @@ secrets:
     rm "$argocd_yaml"
     # </workaround>
 
-    sed -i -e 's:admin$:admin_kcp:g' "$KUBECONFIG_KCP"
+    sed -i'' -e 's:admin$:admin_kcp:g' "$KUBECONFIG_KCP"
     KUBECONFIG="$KUBECONFIG_MERGED" argocd cluster add admin_kcp --name=kcp --yes >/dev/null 2>&1
   fi
   echo "OK"

--- a/local/.utils
+++ b/local/.utils
@@ -23,12 +23,12 @@ wait_command() {
 
 cleanup() {
     if [[ -n "${KCP_PIDS}" ]]; then
-      printf "\nCleaning up processes $KCP_PIDS\n"
-      kill $KCP_PIDS
+      printf "\nCleaning up processes %s\n" "$KCP_PIDS"
+      kill "$KCP_PIDS"
     fi
     if [[ -n "${KCP_CIDS}" ]]; then
-      printf "\nStopping containers $KCP_CIDS\n"
-      $CONTAINER_ENGINE stop $KCP_CIDS
+      printf "\nStopping containers %s\n" "$KCP_CIDS"
+      $CONTAINER_ENGINE stop "$KCP_CIDS"
     fi
 }
 

--- a/local/argocd/setup.sh
+++ b/local/argocd/setup.sh
@@ -25,10 +25,10 @@ pushd "$parent_path"
 
 printf "Installing Argo CD\n"
 
-kubectl --kubeconfig ${KUBECONFIG} create namespace argocd
-kubectl --kubeconfig ${KUBECONFIG} apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl --kubeconfig "${KUBECONFIG}" create namespace argocd
+kubectl --kubeconfig "${KUBECONFIG}" apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 i=0
-while ! kubectl --kubeconfig ${KUBECONFIG} wait deployments ingress-nginx-controller -n ingress-nginx --for=jsonpath='{.status.availableReplicas}'=1 --timeout=1s; do
+while ! kubectl --kubeconfig "${KUBECONFIG}" wait deployments ingress-nginx-controller -n ingress-nginx --for=jsonpath='{.status.availableReplicas}'=1 --timeout=1s; do
 	sleep 1s
 	i=$((i+1))
 	if [ $i -gt 60 ]; then
@@ -36,7 +36,7 @@ while ! kubectl --kubeconfig ${KUBECONFIG} wait deployments ingress-nginx-contro
 		exit 1
 	fi
 done
-kubectl --kubeconfig ${KUBECONFIG} apply -f ingress.yaml
+kubectl --kubeconfig "${KUBECONFIG}" apply -f ingress.yaml
 
 printf "Argo CD installed\n"
 

--- a/local/kind/setup.sh
+++ b/local/kind/setup.sh
@@ -38,7 +38,7 @@ prechecks () {
 
 mk_tmpdir () {
   TMP_DIR="$(mktemp -d -t kind-pipelines-service.XXXXXXXXX)"
-  printf "Temporary directory created: ${TMP_DIR}\n"
+  printf "Temporary directory created: %s\n" "${TMP_DIR}"
 }
 
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
@@ -65,6 +65,7 @@ for cluster in "${CLUSTERS[@]}"; do
     clusterExists=""
     if echo "${EXISTING_CLUSTERS}" | grep "$cluster"; then
         clusterExists="1"
+        ${KIND_CMD} export kubeconfig --name "$cluster" --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig"
     fi
 
     # Only create the cluster if it does not exist
@@ -79,7 +80,7 @@ for cluster in "${CLUSTERS[@]}"; do
 		sudo chmod +r "${TMP_DIR}/${cluster}.kubeconfig"
 	fi
 
-	printf "Provisioning ingress router in ${cluster}\n"
+	printf "Provisioning ingress router in %s\n" "${cluster}"
 	kubectl --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig" apply -f ingress-router.yaml
     fi
 
@@ -92,7 +93,7 @@ for cluster in "${CLUSTERS[@]}"; do
 done
 
 NO_ARGOCD="${NO_ARGOCD:-}"
-if [[ "${NO_ARGOCD,,}" != "true" ]]; then
+if [[ $(tr '[:upper:]' '[:lower:]' <<< "$NO_ARGOCD") != "true" ]]; then
 	KUBECONFIG="${TMP_DIR}/${CLUSTERS[0]}.kubeconfig" ../argocd/setup.sh
 fi
 

--- a/local/kind/setup.sh
+++ b/local/kind/setup.sh
@@ -66,6 +66,9 @@ for cluster in "${CLUSTERS[@]}"; do
     if echo "${EXISTING_CLUSTERS}" | grep "$cluster"; then
         clusterExists="1"
         ${KIND_CMD} export kubeconfig --name "$cluster" --kubeconfig "${TMP_DIR}/${cluster}.kubeconfig"
+	if [[  ${KIND_CMD} == "sudo kind" ]]; then
+                sudo chmod +r "${TMP_DIR}/${cluster}.kubeconfig"
+        fi
     fi
 
     # Only create the cluster if it does not exist


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLNSRVCE-236

### Description
This PR fixes incompatibility issues with "local" & ckcp scripts when running on Mac OS and a case when ArgoCD is being installed on existing kind cluster (created from previous script run).
Also contains some fixes recommended by shellcheck.

### To verify
1. For verification of local scripts:
```bash
# Script should succeed (2 kind clusters should be created) and ArgoCD should NOT be installed
NO_ARGOCD=true ./local/kind/setup.sh
# ArgoCD should be installed on existing kind clusters that were provisioned in previous run of the script
NO_ARGOCD=false ./local/kind/setup.sh
```
2. For verification of ckcp scripts:
```bash
# Target clean openshift cluster and run
cd ckcp
# Should print out help for the script
./gitops.sh -h
# Should deploy ArgoCD with ckcp and pipelines
./gitops.sh -a pipelines
# Should run in a debug mode
./gitops.sh --debug
# Should deploy ArgoCD with ckcp, pipelines and triggers
./gitops.sh --all
```