### PR TITLE
Automation of the registration of clusters into Argo CD  following a GitOps approach

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,17 @@ Argo CD web UI is accessible at https://argocd-server-argocd.apps.127.0.0.1.nip.
 
 GitOps is the preferred approach for deploying the Pipelines Service. The installed instance of ArgoCD can be leveraged for creating organisations in kcp, universal workspaces used by the infrastructure, installing the Tekton controllers and registering the workload clusters.
 
-This is currently being worked on. Automation and documentation will be added very soon.
+[The Argo CD page](./docs/argocd.md) provides instructions to register workload clusters to Argo CD.
+
+In a development environment a few network and name resolution aspects need to be taken into consideration:
+- argocd-server-argocd.apps.127.0.0.1.nip.io is resolved to 127.0.0.1, which is not suitable for communication between containers. When running the argocd container for registration `--add-host argocd-server-argocd.apps.127.0.0.1.nip.io:<kind-cluster-ip-address>` can help with name resolution. The IP address of the kind cluster can be retrieved by inspecting the kind container and taking the value of IPAddress for the kind network.
+- certificates may not have been signed for the argocd-server-argocd.apps.127.0.0.1.nip.io route. `--env INSECURE='true'` can be used for working around this point.
+- make sure that iptables/firewalld are not preventing the communication between the localhost and the containers.
+
+Here is an example for running the registration image in a development environment:
+~~~
+podman run --add-host argocd-server-argocd.apps.127.0.0.1.nip.io:10.89.0.26 --env INSECURE='true' --env ARGO_URL='argocd-server-argocd.apps.127.0.0.1.nip.io:443' --env ARGO_USER='admin' --env ARGO_PWD='xxxxxxxx' --env DATA_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace quay.io/myuser/pipelines-argocd
+~~~
 
 ## Tearing down the environment
 

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -1,0 +1,43 @@
+# Argo CD registration
+
+The [images/argocd directory](../images/argocd) directory contains the logic used for registering the clusters to Argo CD.
+
+## Run
+
+The registration is meant to be triggered from [Pipelines as Code](https://pipelinesascode.com/) and a [Tekton PipelineRun](../gitops/pac/.tekton/argo-registration.yaml) is provided for the purpose in the .tekton directory.
+
+Alternatively the registration can be performed by manually calling the registration script in the image directory:
+
+```console
+ARGO_URL="https://argoserver.com" ARGO_USER="user" ARGO_PWD="xxxxxxxxx" DATA_DIR="/workspace" ./register.sh
+```
+
+DATA_DIR should point to a directory with a fork of this repository including
+- the kubeconfig files of the clusters to register in `gitops/credentials/kubeconfig/compute`
+- two kustomization files for each cluster under two folders:
+  - `gitops/environment/compute/$cluster/namespaces/kustomization.yaml` using `gitops/environment/compute/base/namespaces` as base and any desired customization.
+  - `gitops/environment/compute/$cluster/argocd-rbac/kustomization.yaml` using `gitops/environment/compute/base/argocd-rbac` as base and any desired customization.
+
+~~~
+cat <<EOF > kustomization.yaml
+resources:
+- ../../base/namespaces
+EOF
+~~~
+
+~~~
+cat <<EOF > kustomization.yaml
+resources:
+- ../../base/argocd-rbac
+EOF
+~~~
+
+## Authentication
+
+Tekton PipelineRun relies on a secret named argocd-credentials in the same namespace as the PipelineRun for the authentication against the Argo CD server. This can be created as follows:
+~~~
+kubectl create secret generic argocd-credentials \
+  --from-literal=url='argocd-server.argocd' \
+  --from-literal=user='admin' \
+  --from-literal=pwd='xxxxxxxxx'
+~~~

--- a/gitops/credentials/kubeconfig/.gitignore
+++ b/gitops/credentials/kubeconfig/.gitignore
@@ -1,0 +1,7 @@
+# Ignore everything
+*
+# Apart from
+!README.md
+!.gitignore
+!compute/
+!compute/.gitignore

--- a/gitops/credentials/kubeconfig/README.md
+++ b/gitops/credentials/kubeconfig/README.md
@@ -1,0 +1,10 @@
+# Clusters credentials 
+
+This directory and sub-directories' purpose is to contain the kubeconfig files used for registering the clusters to Argo CD.
+
+---
+**_NOTES:_**
+
+The information contained in kubeconfig files is confidential. Measures should be taken to protect it from being disclosed. This directory and sub-directories should not contain these files in a public repository. Don't forget to amend the `.gitignore` file if you want to add other files to a private fork of this repository.
+
+---

--- a/gitops/credentials/kubeconfig/compute/.gitignore
+++ b/gitops/credentials/kubeconfig/compute/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything
+*
+# Apart from
+!.gitignore

--- a/gitops/environment/compute/base/argocd-rbac/argo-syncer-role.yaml
+++ b/gitops/environment/compute/base/argocd-rbac/argo-syncer-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-manager-role
+  namespace: kcp-syncer
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/gitops/environment/compute/base/argocd-rbac/argo-syncer-rolebinding.yaml
+++ b/gitops/environment/compute/base/argocd-rbac/argo-syncer-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-role-binding
+  namespace: kcp-syncer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-manager-role
+subjects:
+- kind: ServiceAccount
+  name: argocd-manager
+  namespace: argocd-management

--- a/gitops/environment/compute/base/argocd-rbac/argo-tekton-role.yaml
+++ b/gitops/environment/compute/base/argocd-rbac/argo-tekton-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-manager-role
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/gitops/environment/compute/base/argocd-rbac/argo-tekton-rolebinding.yaml
+++ b/gitops/environment/compute/base/argocd-rbac/argo-tekton-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-role-binding
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-manager-role
+subjects:
+- kind: ServiceAccount
+  name: argocd-manager
+  namespace: argocd-management

--- a/gitops/environment/compute/base/argocd-rbac/kustomization.yaml
+++ b/gitops/environment/compute/base/argocd-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- argo-syncer-role.yaml
+- argo-syncer-rolebinding.yaml
+- argo-tekton-role.yaml
+- argo-tekton-rolebinding.yaml

--- a/gitops/environment/compute/base/namespaces/kcp-syncer-ns.yaml
+++ b/gitops/environment/compute/base/namespaces/kcp-syncer-ns.yaml
@@ -1,0 +1,9 @@
+# This file defines the namespace where the syncer runs
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-syncer
+  labels:
+    app.kubernetes.io/name: kcp-syncer
+    kubernetes.io/metadata.name: kcp-syncer
+

--- a/gitops/environment/compute/base/namespaces/kustomization.yaml
+++ b/gitops/environment/compute/base/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- kcp-syncer-ns.yaml
+- management-ns.yaml
+- tekton-ns.yaml

--- a/gitops/environment/compute/base/namespaces/management-ns.yaml
+++ b/gitops/environment/compute/base/namespaces/management-ns.yaml
@@ -1,0 +1,9 @@
+# This file defines the namespace for the ServiceAccount used by Argo CD
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd-management
+  labels:
+    app.kubernetes.io/name: argocd-management
+    kubernetes.io/metadata.name: argocd-management
+

--- a/gitops/environment/compute/base/namespaces/tekton-ns.yaml
+++ b/gitops/environment/compute/base/namespaces/tekton-ns.yaml
@@ -1,0 +1,9 @@
+# This file defines the namespace where the Tekton controllers run
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    kubernetes.io/metadata.name: tekton-pipelines
+

--- a/gitops/pac/.tekton/argo-registration.yaml
+++ b/gitops/pac/.tekton/argo-registration.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: registration-pipeline
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  params:
+    - name: repo_url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: revision
+    workspaces:
+      - name: source
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: depth
+            value: "500"
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      - name: argocd-register
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: register-to-argo
+              image: quay.io/fgiloux/pipelines-argocd:latest
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: ARGO_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "argocd-credentials"
+                      key: "url"
+                - name: ARGO_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "argocd-credentials"
+                      key: "user"
+                - name: ARGO_PWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "argocd-credentials"
+                      key: "pwd"
+                - name: DATA_DIR
+                  value: $(workspaces.source.path)
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Mi

--- a/gitops/pac/README.md
+++ b/gitops/pac/README.md
@@ -37,4 +37,4 @@ KUBECONFIG="/pathto/kubeconfig" GITOPS_REPO="https://gitops.org.com/org/pipeline
 
 ## Pipelines
 
-A pipeline for the registration of new clusters to ArgoCD and kcp will shortly be made available.
+A pipeline for the registration of new clusters to ArgoCD is available. The registration to kcp will shortly be made available as well.

--- a/gitops/pac/setup.sh
+++ b/gitops/pac/setup.sh
@@ -62,7 +62,7 @@ check_params() {
 controller_install() {
     CONTROLLER_INSTALL="${CONTROLLER_INSTALL:-}"
     if [[ $(tr '[:upper:]' '[:lower:]' <<< "$CONTROLLER_INSTALL") == "true" ]]; then
-        printf "Installing controller\n"
+       printf "Installing controller\n"
        kubectl --kubeconfig ${KUBECONFIG} apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.k8s.yaml
     fi
 }

--- a/images/argocd/Dockerfile
+++ b/images/argocd/Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+WORKDIR /
+RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+# Select desired TAG from https://github.com/argoproj/argo-cd/releases
+COPY ./register.sh /usr/local/bin/register.sh
+RUN JQ_VERSION=1.6 &&\
+    curl -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
+    chmod +x /usr/local/bin/jq
+RUN ARGO_VERSION=v2.3.3 && \
+    curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$ARGO_VERSION/argocd-linux-amd64 && \
+    chmod +x /usr/local/bin/argocd
+RUN KUBE_VERSION=v1.24.0 && \
+    curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
+USER 65532:65532
+VOLUME /workspace
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/register.sh"]

--- a/images/argocd/register.sh
+++ b/images/argocd/register.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The pipelines-service Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+
+    printf "Usage: ARGO_URL="https://argoserver.com" ARGO_USER="user" ARGO_PWD="xxxxxxxxx" DATA_DIR="/workspace" ./register.sh\n\n"
+
+    # Parameters
+    printf "The following parameters need to be passed to the script:\n"
+    printf "ARGO_URL: the address of the Argo CD server the clusters need to be registered to\n"
+    printf "ARGO_USER: the user for the authentication\n"
+    printf "ARGO_PWD: the password for the authentication\n"
+    printf "DATA_DIR: the location of the cluster files\n"
+    printf "INSECURE (optional): whether insecured connection to Argo CD should be allowed. Default value: false\n\n"
+}
+
+prechecks () {
+    if ! command -v argocd &> /dev/null; then
+        printf "Argocd CLI could not be found\n"
+    	exit 1
+    fi
+    ARGO_URL=${ARGO_URL:-}
+    if [[ -z "${ARGO_URL}" ]]; then
+        printf "ARGO_URL not set\n\n"
+        usage
+        exit 1	
+    fi
+    ARGO_USER=${ARGO_USER:-}
+    if [[ -z "${ARGO_USER}" ]]; then
+        printf "ARGO_USER not set\n\n"
+        usage
+	exit 1
+    fi
+    ARGO_PWD=${ARGO_PWD:-}
+    if [[ -z "${ARGO_PWD}" ]]; then
+	printf "ARGO_PWD not set\n\n"
+        usage
+	exit 1
+    fi
+    DATA_DIR=${DATA_DIR:-}
+    if [[ -z "${DATA_DIR}" ]]; then
+        printf "DATA_DIR not set\n\n"
+        usage
+	exit 1
+    fi
+    INSECURE=${INSECURE:-}
+    if [[ $(tr '[:upper:]' '[:lower:]' <<< "$INSECURE") == "true" ]]; then
+	printf "insecured connection to Argo CD allowed!\n"
+        insecure="--insecure"
+    else
+        insecure=""
+    fi
+}
+
+# populate clusters with the cluster names taken from the kubconfig
+# populate contexts with the context name taken from the kubeconfig
+# populate kubconfigs with the associated kubeconfig for each cluster name
+# only consider the first context for a specific cluster
+get_clusters() {
+    clusters=()
+    contexts=()
+    kubeconfigs=()
+    files=($(ls $DATA_DIR/gitops/credentials/kubeconfig/compute))
+    for kubeconfig in "${files[@]}"; do
+        subs=($(KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfig} kubectl config view -o jsonpath='{range .contexts[*]}{.name}{","}{.context.cluster}{"\n"}{end}'))
+        for sub in "${subs[@]}"; do
+            context=$(echo -n ${sub} | cut -d ',' -f 1)
+            cluster=$(echo -n ${sub} | cut -d ',' -f 2)
+	    if ! (echo "${clusters[@]}" | grep "${cluster}"); then
+                clusters+=( ${cluster} )
+                contexts+=( ${context} )
+                kubeconfigs+=( ${kubeconfig} )
+            fi
+        done
+    done
+}
+
+registration() {
+    printf "Logging into Argo CD\n"
+    # TODO: there may be a better way than user/password
+    # there should be no assumption that Argo CD runs on the same cluster
+    argocd ${insecure} login $ARGO_URL --username $ARGO_USER --password $ARGO_PWD
+
+    printf "Getting the list of registered clusters\n"
+    existing_clusters=$(argocd cluster list -o json | jq '.[].name')
+
+    for i in "${!clusters[@]}"; do
+        printf "Processing cluster %s\n" "${clusters[$i]}"
+        if echo "${existing_clusters}" | grep "${clusters[$i]}"; then
+            printf "Cluster already registered\n"
+        else
+            printf "Registering cluster\n"
+            # Split between namespace creation and application of rbac policies:
+            # - `argocd cluster add` requires the namespaces to exist
+            # - `argocd cluster add` applies default rbac that may differ from what is desired
+            KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply -k ${DATA_DIR}/gitops/environment/compute/${clusters[$i]}/namespaces
+            KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfigs[$i]} argocd -y ${insecure} cluster add "${contexts[$i]}" --system-namespace argocd-management --namespace=tekton-pipelines --namespace=kcp-syncer
+            KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply -k ${DATA_DIR}/gitops/environment/compute/${clusters[$i]}/argocd-rbac
+        fi
+    done
+}
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+prechecks
+
+printf "Retrieving clusters\n"
+get_clusters
+
+printf "Registering clusters and provisioning credentials for Argo CD\n"
+registration
+


### PR DESCRIPTION
Goal: Providing a GitOps approach to automate the registration of clusters into Argo CD.

Content: 
- a PipelineRun integrated into Pipelines as Code, which automate the registration from a repo push or PR
- a container image for supporting the Task
- a script with the necessary logic
- manifests for namespaces and rbac
- documentation

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>