### PR TITLE
Remove port number from cluster name in register.sh

### DIFF
--- a/images/argocd/register.sh
+++ b/images/argocd/register.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+# set -x
 
 usage() {
 
@@ -82,7 +83,7 @@ get_clusters() {
         subs=($(KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfig} kubectl config view -o jsonpath='{range .contexts[*]}{.name}{","}{.context.cluster}{"\n"}{end}'))
         for sub in "${subs[@]}"; do
             context=$(echo -n ${sub} | cut -d ',' -f 1)
-            cluster=$(echo -n ${sub} | cut -d ',' -f 2)
+            cluster=$(echo -n ${sub} | cut -d ',' -f 2 | cut -d ':' -f 1)
 	    if ! (echo "${clusters[@]}" | grep "${cluster}"); then
                 clusters+=( ${cluster} )
                 contexts+=( ${context} )


### PR DESCRIPTION
The cluster name has the port number when specified in the kubeconfig. Since this impact the naming of the folders, it's probably better to ignore the port when present.