### PR TITLE
Automation of the registration of clusters into kcp following a GitOps approach

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ Prerequisites:
 
 ## Workload clusters with kind
 
-[./local/kind/setup.sh](./local/kind/setup.sh) will create two kind clusters and the files to register them so that it is straightforward to add them to the kcp cluster. Kind will also output the kubeconfig files that can be used to interact with the Kubernetes clusters. Simply run:
+[./local/kind/setup.sh](./local/kind/setup.sh) will create two kind clusters and output the kubeconfig files that can be used to interact with the Kubernetes clusters. An amended version of the kubeconfig file with the suffix '_ip' can be used for registering the clusters to Argo CD. A routable IP is used instead of localhost. Simply run:
 
 ```console
 ./local/kind/setup.sh
@@ -52,6 +52,25 @@ The script will output the location of the kubeconfig file that can be used to i
 **_NOTE:_**  podman is used per default as container engine if available on the machine. If both podman and docker are available it is possible to force the use of docker by setting an environment variable `CONTAINER_ENGINE=docker`.
 
 ---
+
+[The kcp registration page](./docs/kcp-registration.md) provides instructions to register workload clusters to kcp.
+
+Here is an example for running the registration image in a development environment:
+~~~
+podman run --env KCP_ORG='root:pipelines-service' --env KCP_WORKSPACE='compute' --env DATA_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace quay.io/myuser/pipelines-kcp
+~~~
+
+Make sure that iptables/firewalld are not preventing the communication (tcp initiated from the kind clusters) between the containers running on the kind network and the kcp process on the host.
+
+To check iptables rules:
+~~~
+sudo iptables -L -n -v
+~~~
+
+The following command can be used to insert a new rule allowing the podman network `10.88.0.1/24` to access the port `6443` of the kcp API server running on a host with IP `192.168.0.121`:
+~~~
+sudo iptables -I INPUT -p tcp --src 10.88.0.1/24 --dport 6443 --dst 192.168.0.121 -j ACCEPT
+~~~
 
 ## Gateway
 

--- a/docs/kcp-registration.md
+++ b/docs/kcp-registration.md
@@ -1,0 +1,23 @@
+# kcp registration
+
+The [images/kcp-registrar directory](../images/kcp-registrar) contains the logic used for registering workload clusters to kcp.
+
+## Run
+
+The registration is meant to be triggered from [Pipelines as Code](https://pipelinesascode.com/) and a [Tekton PipelineRun](../gitops/pac/.tekton/kcp-registration.yaml) is provided for the purpose in the .tekton directory.
+
+Alternatively the registration can be performed by manually calling the registration script in the image directory:
+
+```console
+KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" DATA_DIR="/workspace" ./register.sh
+```
+
+| Name | Description |
+|------|-------------|
+| KCP_ORG | contains the organistation for which the workload clusters need to be registered, i.e.: root:pipelines-service|
+| KCP_WORKSPACE | contains the name of the workspace where the workload clusters get registered (created if it does not exist), i.e: compute|
+| DATA_DIR | specifies the location of the cluster files<br> - a single file with extension kubeconfig is expected in the subdirectory: `gitops/credentials/kubeconfig/kcp`<br> - kubeconfig files for compute clusters are expected in the subdirectory: `gitops/credentials/kubeconfig/compute`|
+
+## Authentication
+
+The authentication to kcp and the workload clusters is done through the provided kubeconfig files.

--- a/gitops/pac/.tekton/kcp-registration.yaml
+++ b/gitops/pac/.tekton/kcp-registration.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kcp-registration-pipeline
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+  params:
+    - name: repo_url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: revision
+    workspaces:
+      - name: source
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: depth
+            value: "500"
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      - name: kcp-register
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: register-to-kcp
+              # TODO: move to a different repository
+              image: quay.io/fgiloux/pipelines-kcp:latest
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: DATA_DIR
+                  value: $(workspaces.source.path)
+                - name: KCP_ORG
+                  value: "pipelines-service"
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Mi

--- a/gitops/pac/README.md
+++ b/gitops/pac/README.md
@@ -37,4 +37,4 @@ KUBECONFIG="/pathto/kubeconfig" GITOPS_REPO="https://gitops.org.com/org/pipeline
 
 ## Pipelines
 
-A pipeline for the registration of new clusters to ArgoCD is available. The registration to kcp will shortly be made available as well.
+Pipelines for the registration of new clusters to ArgoCD and kcp are available.

--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -1,0 +1,42 @@
+# Build the binary
+FROM golang:1.17 AS builder
+
+WORKDIR /workspace
+USER 0
+RUN apt-get update && apt-get install -y jq && mkdir bin
+RUN git clone https://github.com/kcp-dev/kcp.git && cd kcp && \
+    BRANCH=release-0.4 && git checkout $BRANCH && \
+    CGO_ENABLED=0 make
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+LABEL build-date= \
+      com.redhat.build-host= \
+      description="This image provides binaries and a script to easily register clusters to kcp." \
+      distribution-scope="public" \
+      io.k8s.description="This image provides binaries and a script to easily register clusters to kcp." \
+      io.k8s.display-name="kcp register" \
+      maintainer="Pipelines Service" \
+      name="kcp-registrar" \
+      release="0.1" \
+      summary="Provides the latest release of kcp-registrar image." \
+      url="https://github.com/openshift-pipelines/pipelines-service/tree/main/images/kcp-registrar" \
+      vcs-ref=  \
+      vcs-type="git" \
+      vendor="Pipelines Service" \
+      version="0.1"
+WORKDIR /
+RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+COPY --from=builder workspace/kcp/bin/kubectl-kcp /usr/local/bin/kubectl-kcp
+RUN chmod 755 /usr/local/bin/kubectl-kcp
+COPY ./register.sh /usr/local/bin/register.sh
+RUN chmod 755 /usr/local/bin/register.sh
+RUN JQ_VERSION=1.6 && \
+    curl -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
+    chmod 755 /usr/local/bin/jq
+RUN KUBE_VERSION=v1.24.0 && \
+    curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
+    chmod 755 /usr/local/bin/kubectl
+USER 65532:65532
+VOLUME /workspace
+WORKDIR /workspace
+CMD ["/usr/local/bin/register.sh"]

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The pipelines-service Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+
+    printf "Usage: KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" DATA_DIR="/workspace" ./register.sh\n\n"
+
+    # Parameters
+    printf "The following parameters need to be passed to the script:\n"
+    printf "KCP_ORG: the organistation for which the workload clusters need to be registered, i.e.: root:pipelines-service\n"
+    printf "KCP_WORKSPACE: the name of the workspace where the workload clusters get registered (created if it does not exist), i.e: compute\n"
+    printf "DATA_DIR: the location of the cluster files\n"
+    printf "          a single file with extension kubeconfig is expected in the subdirectory: gitops/credentials/kubeconfig/kcp\n"
+    printf "          kubeconfig files for compute clusters are expected in the subdirectory: gitops/credentials/kubeconfig/compute \n\n"
+}
+
+prechecks () {
+    KCP_ORG=${KCP_ORG:-}
+    if [[ -z "${KCP_ORG}" ]]; then
+        printf "KCP_ORG not set\n\n"
+        usage
+        exit 1
+    fi
+
+    KCP_ORG=${KCP_WORKSPACE:-}
+    if [[ -z "${KCP_WORKSPACE}" ]]; then
+        printf "KCP_WORKSPACE not set\n\n"
+        usage
+        exit 1
+    fi
+    
+    DATA_DIR=${DATA_DIR:-}
+    if [[ -z "${DATA_DIR}" ]]; then
+        printf "DATA_DIR not set\n\n"
+        usage
+	exit 1
+    fi
+}
+
+# populate kcp_kcfg with the location of the kubeconfig for connecting to kcp
+kcp_kubeconfig() {
+    if files=($(ls $DATA_DIR/gitops/credentials/kubeconfig/kcp/*.kubeconfig 2>/dev/null)); then
+        if [ ${#files[@]} -ne 1 ]; then
+            printf "A single kubeconfig file is expected at %s" "$DATA_DIR/gitops/credentials/kubeconfig/kcp\n"
+            usage
+            exit 1
+        fi
+        kcp_kcfg="${files[0]}"
+    else
+        printf "A single kubeconfig file is expected at %s" "$DATA_DIR/gitops/credentials/kubeconfig/kcp\n"
+        usage
+        exit 1
+    fi
+}
+
+# populate clusters with the cluster names taken from the kubconfig
+# populate contexts with the context name taken from the kubeconfig
+# populate kubconfigs with the associated kubeconfig for each cluster name
+# only consider the first context for a specific cluster
+get_clusters() {
+    clusters=()
+    contexts=()
+    kubeconfigs=()
+    files=($(ls $DATA_DIR/gitops/credentials/kubeconfig/compute))
+    for kubeconfig in "${files[@]}"; do
+        subs=($(KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfig} kubectl config view -o jsonpath='{range .contexts[*]}{.name}{","}{.context.cluster}{"\n"}{end}'))
+        for sub in "${subs[@]}"; do
+            context=$(echo -n ${sub} | cut -d ',' -f 1)
+            cluster=$(echo -n ${sub} | cut -d ',' -f 2)
+	    if ! (echo "${clusters[@]}" | grep "${cluster}"); then
+                clusters+=( ${cluster} )
+                contexts+=( ${context} )
+                kubeconfigs+=( ${kubeconfig} )
+            fi
+        done
+    done
+}
+
+switch_org() {
+    KUBECONFIG=${kcp_kcfg} kubectl kcp workspace use ${KCP_ORG}
+    if ! (KUBECONFIG=${kcp_kcfg} kubectl api-resources >> /dev/null 2>&1); then
+        printf "%s is not a valid organization, wrong kubectl context in use or connectivity issue\n" ${KCP_ORG}
+	usage
+	exit 1
+    fi
+}
+
+switch_ws() {
+    if (KUBECONFIG=${kcp_kcfg} kubectl get workspaces -o name | grep "${KCP_WORKSPACE}"); then
+        printf "use existing workspace\n"
+	KUBECONFIG=${kcp_kcfg} kubectl kcp workspace use ${KCP_WORKSPACE}
+
+    else
+       printf "creating workspace %s\n" "${KCP_WORKSPACE}"
+       KUBECONFIG=${kcp_kcfg} kubectl kcp workspace create "${KCP_WORKSPACE}" --enter
+    fi
+}
+
+register() {
+    printf "Getting the list of registered clusters\n"
+    existing_clusters=$(KUBECONFIG=${kcp_kcfg} kubectl get workloadclusters -o name)
+
+    for i in "${!clusters[@]}"; do
+        printf "Processing cluster %s\n" "${clusters[$i]}"
+        if echo "${existing_clusters}" | grep "${clusters[$i]}"; then
+            printf "Cluster already registered\n"
+        else
+            printf "Registering cluster\n"
+            KUBECONFIG=${kcp_kcfg} kubectl kcp workload sync "${clusters[$i]}" \
+                 --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.4 \
+		 --resources deployments.apps,services,ingresses.networking.k8s.io,conditions.tekton.dev,pipelines.tekton.dev,pipelineruns.tekton.dev,pipelineresources.tekton.dev,runs.tekton.dev,tasks.tekton.dev,taskruns.tekton.dev > /tmp/syncer-${clusters[$i]}.yaml
+            KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply --context ${contexts[$i]} -f /tmp/syncer-${clusters[$i]}.yaml 
+        fi
+    done
+}
+
+kcp_kubeconfig
+printf "Switching to organization %s\n" ${KCP_ORG}
+switch_org
+printf "Switching to workspace %s\n" ${KCP_WORKSPACE}
+switch_ws
+get_clusters
+printf "Registering clusters to kcp\n"
+register
+

--- a/local/kcp/pipelines-service-org.yaml
+++ b/local/kcp/pipelines-service-org.yaml
@@ -1,0 +1,6 @@
+apiVersion: tenancy.kcp.dev/v1alpha1
+kind: ClusterWorkspace
+metadata:
+  name: pipelines-service
+spec:
+  type: Organization

--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -87,6 +87,12 @@ envoy-start() {
   KCP_CIDS="${KCP_CIDS}  ${ENVOY_CID}"
 }
 
+create-org() {
+  printf "Creating organization\n"
+  kubectl --kubeconfig="${KUBECONFIG}" config use-context root
+  kubectl --kubeconfig="${KUBECONFIG}" create -f "${PARENT_PATH}"/pipelines-service-org.yaml
+}
+
 # Execution
 
 kcp-binaries
@@ -118,6 +124,7 @@ fi
 kcp-start
 ingress-ctrler-start
 envoy-start
+create-org
 
 touch "${TMP_DIR}/servers-ready"
 


### PR DESCRIPTION
Goal: Providing a GitOps approach to automate the registration of clusters into kcp.

Content:

- a PipelineRun integrated into Pipelines as Code, which automate the registration from a repo push or PR
- a container image for supporting the Task
- a script with the necessary logic
- documentation

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>