### PR TITLE
Change event triggering Argo CD registration from pull request to push

### DIFF
--- a/gitops/pac/.tekton/argo-registration.yaml
+++ b/gitops/pac/.tekton/argo-registration.yaml
@@ -4,7 +4,7 @@ metadata:
   name: registration-pipeline
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
 spec:
   params:
     - name: repo_url

--- a/images/argocd/Dockerfile
+++ b/images/argocd/Dockerfile
@@ -5,13 +5,13 @@ RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 COPY ./register.sh /usr/local/bin/register.sh
 RUN JQ_VERSION=1.6 &&\
     curl -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
-    chmod +x /usr/local/bin/jq
+    chmod +755 /usr/local/bin/jq
 RUN ARGO_VERSION=v2.3.3 && \
     curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$ARGO_VERSION/argocd-linux-amd64 && \
-    chmod +x /usr/local/bin/argocd
+    chmod +755 /usr/local/bin/argocd
 RUN KUBE_VERSION=v1.24.0 && \
     curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
-    chmod +x /usr/local/bin/kubectl
+    chmod +755 /usr/local/bin/kubectl
 USER 65532:65532
 VOLUME /workspace
 WORKDIR /workspace


### PR DESCRIPTION
- Similar to the registration to kcp "push" is the right event and not "pull request". The workflow only need to get triggered when the change has been merged.
- Align the permissions on binaries with what is done for the kcp image

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>