### PR TITLE
Add $HOME environment variable to container images

### DIFF
--- a/exploration/argocd-external/images/argocd-registrar/Dockerfile
+++ b/exploration/argocd-external/images/argocd-registrar/Dockerfile
@@ -15,7 +15,9 @@ LABEL build-date= \
       vendor="Pipelines Service" \
       version="0.1"
 WORKDIR /
+ENV HOME /tmp/home
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+RUN mkdir $HOME && chmod 777 $HOME
 # Select desired TAG from https://github.com/argoproj/argo-cd/releases
 COPY ./register.sh /usr/local/bin/register.sh
 RUN JQ_VERSION=1.6 &&\

--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -25,7 +25,9 @@ LABEL build-date= \
       vendor="Pipelines Service" \
       version="0.1"
 WORKDIR /
+ENV HOME /tmp/home
 RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
+RUN mkdir $HOME && chmod 777 $HOME
 COPY --from=builder workspace/kcp/bin/kubectl-kcp /usr/local/bin/kubectl-kcp
 RUN chmod 755 /usr/local/bin/kubectl-kcp
 COPY ./register.sh /usr/local/bin/register.sh

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -58,13 +58,13 @@ prechecks () {
 kcp_kubeconfig() {
     if files=($(ls $DATA_DIR/gitops/credentials/kubeconfig/kcp/*.kubeconfig 2>/dev/null)); then
         if [ ${#files[@]} -ne 1 ]; then
-            printf "A single kubeconfig file is expected at %s" "$DATA_DIR/gitops/credentials/kubeconfig/kcp\n"
+            printf "A single kubeconfig file is expected at %s\n" "$DATA_DIR/gitops/credentials/kubeconfig/kcp"
             usage
             exit 1
         fi
         kcp_kcfg="${files[0]}"
     else
-        printf "A single kubeconfig file is expected at %s" "$DATA_DIR/gitops/credentials/kubeconfig/kcp\n"
+        printf "A single kubeconfig file is expected at %s\n" "$DATA_DIR/gitops/credentials/kubeconfig/kcp"
         usage
         exit 1
     fi


### PR DESCRIPTION
Add $HOME environment variable to container images as it is used:
- for docker credentials
- for storing kubectl cache

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>