### PR TITLE
Use ghcr repository and instruct PaC to fetch remote Tasks if necessary

### DIFF
--- a/exploration/argocd-external/gitops/pac/.tekton/argo-registration.yaml
+++ b/exploration/argocd-external/gitops/pac/.tekton/argo-registration.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/task: "git-clone"
 spec:
   params:
     - name: repo_url
@@ -42,7 +43,7 @@ spec:
             - name: source
           steps:
             - name: register-to-argo
-              image: quay.io/fgiloux/pipelines-argocd:latest
+              image: ghcr.io/openshift-pipelines/argocd-registrar:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: ARGO_URL

--- a/gitops/pac/.tekton/kcp-registration.yaml
+++ b/gitops/pac/.tekton/kcp-registration.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/task: "git-clone"
 spec:
   params:
     - name: repo_url
@@ -42,8 +43,7 @@ spec:
             - name: source
           steps:
             - name: register-to-kcp
-              # TODO: move to a different repository
-              image: quay.io/fgiloux/pipelines-kcp:latest
+              image: ghcr.io/openshift-pipelines/kcp-registrar:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: DATA_DIR


### PR DESCRIPTION
Use the ghcr repository for the pipelines-service.
Instruct PaC to fetch remote Tasks if necessary.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>