### PR TITLE
Modified kcp version to release-0.5

### DIFF
--- a/.github/workflows/kcp-registrar-image.yaml
+++ b/.github/workflows/kcp-registrar-image.yaml
@@ -35,6 +35,8 @@ jobs:
           tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
           containerfiles: |
             ./images/kcp-registrar/Dockerfile
+          build-args: |
+            KCP_BRANCH=release-0.5
 
       - name: Push to ghcr.io
         id: push-to-ghcr

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Controllers know nothing about kcp.
 
 ![Phase 1 flow](./docs/images/phase1.png)
 
+**[Limitations](./docs/phase1_limitations.md)**
+
 **Demo** (5mns)
 
 [![asciicast](https://asciinema.org/a/duvHbVhNXvX1AeISR2sGBpvAY.svg)](https://asciinema.org/a/duvHbVhNXvX1AeISR2sGBpvAY)

--- a/ckcp/openshift/overlays/dev/kustomization.yaml
+++ b/ckcp/openshift/overlays/dev/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
 images:
 - name: kcp
   newName: ghcr.io/kcp-dev/kcp
-  newTag: release-0.4
+  newTag: release-0.5
 
 namespace: ckcp

--- a/docs/phase1_limitations.md
+++ b/docs/phase1_limitations.md
@@ -1,0 +1,12 @@
+# Phase 1 Limitations
+
+
+## ServiceAccount used by TaskRuns and PipelineRuns
+The `default` SA in kcp workspace has the secret containing its token synchronised in the workload cluster but under a different name (with `kcp` prefix). In phase 1 we don't want Tekton pods to communicate with the kcp API. As such they should not use an SA and its token created by kcp. This is a limitation but an existing SA from the workload cluster can be used instead.
+
+### Instructions
+When you create a TaskRun or a PipelineRun you have the following options:
+* Not specifying an SA is valid
+* The `pipeline` SA can be used
+* The `default` SA does not work as it would point to the KCP API
+* A custom SA created in kcp workspace may have the same flaw for our phase 1 approach

--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -1,11 +1,14 @@
 # Build the binary
 FROM golang:1.17 AS builder
 
+ARG KCP_BRANCH
+ENV KCP_TAG=${KCP_BRANCH}
+
 WORKDIR /workspace
 USER 0
 RUN apt-get update && apt-get install -y jq && mkdir bin
 RUN git clone https://github.com/kcp-dev/kcp.git && cd kcp && \
-    BRANCH=release-0.4 && git checkout $BRANCH && \
+    BRANCH=$KCP_BRANCH && git checkout $BRANCH && \
     CGO_ENABLED=0 make
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -124,7 +124,7 @@ register() {
         else
             printf "Registering cluster\n"
             KUBECONFIG=${kcp_kcfg} kubectl kcp workload sync "${clusters[$i]}" \
-                 --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.4 \
+                 --syncer-image ghcr.io/kcp-dev/kcp/syncer:$KCP_TAG \
 		 --resources deployments.apps,services,ingresses.networking.k8s.io,conditions.tekton.dev,pipelines.tekton.dev,pipelineruns.tekton.dev,pipelineresources.tekton.dev,runs.tekton.dev,tasks.tekton.dev,taskruns.tekton.dev > /tmp/syncer-${clusters[$i]}.yaml
             KUBECONFIG=${DATA_DIR}/gitops/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply --context ${contexts[$i]} -f /tmp/syncer-${clusters[$i]}.yaml 
         fi

--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -32,7 +32,7 @@ precheck() {
 }
 
 KCP_DIR="${KCP_DIR:-}"
-kcp-binaries () {
+kcp-binaries() {
   if [[ -z "${KCP_DIR}" ]]; then
     precheck git
     KCP_PARENT_DIR="$(mktemp -d -t kcp.XXXXXXXXX)"
@@ -40,7 +40,7 @@ kcp-binaries () {
     git clone https://github.com/kcp-dev/kcp.git
     KCP_DIR="${KCP_PARENT_DIR}/kcp"
     pushd kcp
-    KCP_BRANCH="${KCP_BRANCH:-release-0.4}"
+    KCP_BRANCH="${KCP_BRANCH:-release-0.5}"
     git checkout "${KCP_BRANCH}"
     make build
     popd
@@ -94,6 +94,7 @@ create-org() {
 }
 
 # Execution
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 kcp-binaries
 
@@ -102,8 +103,6 @@ printf "Temporary directory created: %s\n" "${TMP_DIR}"
 
 KUBECONFIG="${TMP_DIR}/.kcp/admin.kubeconfig"
 printf "KUBECONFIG=%s\n" "${KUBECONFIG}"
-
-PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 source "${PARENT_PATH}/../.utils"
 


### PR DESCRIPTION
**Changes**
1. Modified KCP image to [release-0.5](https://github.com/kcp-dev/kcp/pkgs/container/kcp/24100239?tag=release-0.5)
2. Modified  KCP Syncer image to [release-0.5](https://github.com/kcp-dev/kcp/pkgs/container/kcp%2Fsyncer/24099863?tag=release-0.5 )
3. Modified ./ckcp/test.sh to look for namespace with proper label
4. Modified ./ckcp/test.sh for PipelineRun case by removing serviceAccountName property

**Known Issue**

1. When executing `./ckcp/test.sh pipelines`, the PipelineRun, such like `test-pipelinerun-xxxx` will fail due to the SA token secret being renamed from `default-token-xxxx` in icp to  `kcp-default-token-xxx` on the workload cluster.  It couldn't find the secret.
2. `./ckcp/test.sh` couldn't run the trigger cases, It needs to expose the event listeners through a global load balancer fronting kcp to handle  redirection of the requests


**Testing Locally**
1. Execute `./ckcp/test.sh pipelines` to runs TaskRun and PipelineRun cases