### PR TITLE
Clean up kcp_registrar

### DIFF
--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -1,4 +1,5 @@
 # Build the binary
+# cf https://github.com/kcp-dev/kcp/issues/1092
 FROM golang:1.17 AS builder
 
 ARG KCP_BRANCH
@@ -33,14 +34,14 @@ RUN mkdir /workspace && chmod 777 /workspace && chown 65532:65532 /workspace
 RUN mkdir $HOME && chmod 777 $HOME
 COPY --from=builder workspace/kcp/bin/kubectl-kcp /usr/local/bin/kubectl-kcp
 RUN chmod 755 /usr/local/bin/kubectl-kcp
-COPY ./register.sh /usr/local/bin/register.sh
-RUN chmod 755 /usr/local/bin/register.sh
 RUN JQ_VERSION=1.6 && \
-    curl -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
+    curl --fail -sSL -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64 && \
     chmod 755 /usr/local/bin/jq
 RUN KUBE_VERSION=v1.24.0 && \
-    curl -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
+    curl --fail -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/amd64/kubectl" && \
     chmod 755 /usr/local/bin/kubectl
+COPY ./register.sh /usr/local/bin/register.sh
+RUN chmod 755 /usr/local/bin/register.sh
 USER 65532:65532
 VOLUME /workspace
 WORKDIR /workspace


### PR DESCRIPTION
The logic is mostly unchanged, except:
    1. `register.sh` is copied last to speed up image creation time on the
      local dev env;
    2. the kubeconfig are copied to a tmp folder to workaround ro permissions
      in the container;
    3. all clusters are always processed.

Item #3 is possible because the cluster registration is idempotent as
of kcp release-0.5.
Item #3 is desirable because if anything bad happens while setting up
the cluster, the recovery would require a manual action to delete the
syncer on KCP.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>