### PR TITLE
fixed minor issues about cert-manager

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -167,7 +167,7 @@ install_cert_manager() {
   # # Install the cert manager operator
   # #############################################################################
   echo -n "  - openshift-cert-manager-operator: "
-  if kubectl cert-manager check api | grep -q "Not ready" >/dev/null 2>&1; then
+  if [ $(kubectl cert-manager check api 2>&1 | grep -c "Not ready") -eq 1 ]; then
     kubectl apply -f "$CKCP_DIR/argocd-apps/$APP.yaml" >/dev/null 2>&1
     argocd app wait "$APP" >/dev/null 2>&1
     # Wait until cert manager is ready


### PR DESCRIPTION
**Changes:**
It fixed minor issues
- Fixed the if condition, now it could work in both Mac and Linux
- It could correctly handle the output message for command `kubectl cert-manager check api`, we hope it doesn't print out the message