### PR TITLE
Revert TektonConfig until issue is resolved

### DIFF
--- a/gitops/argocd/tektoncd/kustomization.yaml
+++ b/gitops/argocd/tektoncd/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - openshift-operator.yaml
-  - tekton-config.yaml
+  # Due to some permission issue probably, the TektonConfig is not being applied properly, commenting till the issue is resolved. 
+  # - tekton-config.yaml


### PR DESCRIPTION
It seems TektonConfig is not being applied peoperly due to a permission issue. This PR reverts TektonConfig until the issue is resolved.

Signed-off-by: Avinal Kumar <avinkuma@redhat.com>