### PR TITLE
Sync NetworkPolicy resources with ckcp

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -23,6 +23,7 @@ CR_TOSYNC=(
             runs.tekton.dev
             tasks.tekton.dev
             repositories.pipelinesascode.tekton.dev
+            networkpolicies.networking.k8s.io
           )
 
 usage() {


### PR DESCRIPTION
# Why this PR?
- NetworkPolicy needs to be synced with kcp for us to be able to apply the NetworkPolicy resources in a kcp workspace.
 
Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>