### PR TITLE
PaC setup script and readme changes

### DIFF
--- a/gitops/pac/README.md
+++ b/gitops/pac/README.md
@@ -14,8 +14,9 @@ When a kubeconfig file gets added to a GitOps repository Pipelines as Code trigg
 
 This directory contains the manifests used for installing Pipelines as Code and registering the runners.
 
-Pipelines as Code comes pre-installed with the OpenShit Pipelines Operator. This is what should be used for its [installation on OpenShift](https://docs.openshift.com/container-platform/4.10/cicd/pipelines/installing-pipelines.html).
-The runner registration still needs to be done if it hasn't already.
+Pipelines as Code comes pre-installed with the OpenShift Pipelines Operator. This is what should be used for its [installation on OpenShift](https://docs.openshift.com/container-platform/4.10/cicd/pipelines/installing-pipelines.html).
+_Note: Currently, as we are using OpenShift Pipelines Operator version 1.7 ([here](../../gitops/argocd/tektoncd/openshift-operator.yaml)), it is shipped with Pipelines as Code 0.5.x. Since we require PaC version 0.9.0 or above, we recommend installing the latest version by running the script with the flag CONTROLLER_INSTALL set to true._  
+The runner registration still needs to be done if it hasn't been done already.
 
 A webhook and credentials need to be added on the provider side of the git repository. Follow the [Pipelines as Code instructions](https://pipelinesascode.com/docs/install/) specific to your provider for the purpose.
 

--- a/gitops/pac/setup.sh
+++ b/gitops/pac/setup.sh
@@ -63,7 +63,8 @@ controller_install() {
     CONTROLLER_INSTALL="${CONTROLLER_INSTALL:-}"
     if [[ $(tr '[:upper:]' '[:lower:]' <<< "$CONTROLLER_INSTALL") == "true" ]]; then
        printf "Installing controller\n"
-       kubectl --kubeconfig ${KUBECONFIG} apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.k8s.yaml
+       kubectl --kubeconfig ${KUBECONFIG} patch tektonconfig config --type="merge" -p '{"spec": {"addon":{"enablePipelinesAsCode": false}}}'
+       kubectl --kubeconfig ${KUBECONFIG} apply -f https://github.com/openshift-pipelines/pipelines-as-code/releases/download/0.10.0/release.yaml
     fi
 }
 


### PR DESCRIPTION
This PR contains:
- Set the version of PaC installation from latest release.yaml to version 0.10.0 in pac/setup.sh
- Updated Readme to reflect that users need to set CONTROLLER_INSTALL to true so that version 0.10.0 of PaC is installed through the script.