### PR TITLE
fix: Add work-dir option to ckcp deployment script

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,6 +1,0 @@
-kind: Workspace
-apiVersion: tenancy.kcp.dev/v1alpha1
-metadata:
-  name: demo
-spec:
-  inheritFrom: admin


### PR DESCRIPTION
Since the directory is automatically removed when the script is
executed, use a tmpdir by default and give the option to the user to
specify an alternate directory.

Removed unused workspace.yaml

Format script (remove double spaces, improve indentation).

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>