### PR TITLE
Configure SyncTarget workspace and update APIBinding documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,7 +59,7 @@ The script will output the location of the kubeconfig file that can be used to i
 Here is an example for running the registration image in a development environment:
 
 ```bash
-podman run --env KCP_ORG='root:pipelines-service' --env KCP_WORKSPACE='compute' --env DATA_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace quay.io/myuser/pipelines-kcp
+podman run --env KCP_ORG='root:pipelines-service' --env KCP_WORKSPACE='compute' --env WORKSPACE_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace ghcr.io/openshift-pipelines/kcp-registrar:main
 ```
 
 Make sure that iptables/firewalld is not preventing the communication (tcp initiated from the kind clusters) between the containers running on the kind network and the kcp process on the host.

--- a/docs/kcp-registration.md
+++ b/docs/kcp-registration.md
@@ -9,7 +9,7 @@ The registration is meant to be triggered from [Pipelines as Code](https://pipel
 Alternatively the registration can be performed by manually calling the registration script in the image directory:
 
 ```bash
-KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" KCP_SYNC_TAG="release-0.5" DATA_DIR="/workspace" ./register.sh
+KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" KCP_SYNC_TAG="release-0.5" WORKSPACE_DIR="/workspace" ./register.sh
 ```
 
 | Name | Description |
@@ -17,7 +17,7 @@ KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" KCP_SYNC_TAG="release-0
 | KCP_ORG | contains the organistation for which the workload clusters need to be registered, i.e.: root:pipelines-service|
 | KCP_WORKSPACE | contains the name of the workspace where the workload clusters get registered (created if it does not exist), i.e: compute|
 | KCP_SYNC_TAG | the tag of the kcp syncer image to use (preset in the container image at build time and leveraged by the PipelineRun)|
-| DATA_DIR | specifies the location of the cluster files<br> - a single file with extension kubeconfig is expected in the subdirectory: `gitops/credentials/kubeconfig/kcp`<br> - kubeconfig files for compute clusters are expected in the subdirectory: `gitops/credentials/kubeconfig/compute`|
+| WORKSPACE_DIR | specifies the location of the cluster files<br> - a single file with extension kubeconfig is expected in the subdirectory: `gitops/credentials/kubeconfig/kcp`<br> - kubeconfig files for compute clusters are expected in the subdirectory: `gitops/credentials/kubeconfig/compute`|
 
 ## Authentication
 

--- a/docs/sre/examples/providers/environment/kcp/kustomization.yaml
+++ b/docs/sre/examples/providers/environment/kcp/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - github.com/openshift-pipelines/pipelines-service/gitops/kcp/registration?ref=main
+
+# The default APIBinding RBAC settings could be patched here.

--- a/docs/sre/examples/single_cluster/environment/kcp/kustomization.yaml
+++ b/docs/sre/examples/single_cluster/environment/kcp/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - github.com/openshift-pipelines/pipelines-service/gitops/kcp/registration?ref=main

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -76,7 +76,7 @@ _Note: Please run these scripts only if you intend not to use PaC to automate th
     b. To access and setup kcp
 
     ```
-    $ KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" DATA_DIR="/home/workspace/pipelines-service/gitops/sre" ../images/kcp-registrar/register.sh
+    $ KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" WORKSPACE_DIR="/home/workspace/pipelines-service/gitops/sre" ../images/kcp-registrar/register.sh
     ```
 
 ### Pipelines As Code (PaC)
@@ -172,6 +172,8 @@ spec:
   - rev-158351.deployments.apps
 
 ```
+
+Users must be authorized to bind APIExports on the workspace hosting the SyncTarget, or they will get an `unable to create APIImport: missing verb='bind' permission on apiexports` error. The default configuration will grant the `bind` permission to all authenticated users (c.f. `gitops/kcp/registration`). This configuration can be customized by creating the appropriate manifest(s) in the `environment/kcp` folder (c.f. [this example](../docs/sre/examples/providers/environment/kcp/kustomization.yaml)).
 
 Below snippet shows the APIBinding used in a new workspace named 'user'.
 

--- a/gitops/kcp/registration/clusterrole.yaml
+++ b/gitops/kcp/registration/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apibinding:kubernetes
+rules:
+  - apiGroups:
+      - apis.kcp.dev
+    resources:
+      - apiexports
+    resourceNames:
+      - kubernetes # value of the spec/identity/secretRef/name field of the APIExport
+    verbs:
+      - bind

--- a/gitops/kcp/registration/clusterrolebinding.yaml
+++ b/gitops/kcp/registration/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apibinding:kubernetes:all-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apibinding:kubernetes
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/gitops/kcp/registration/kustomization.yaml
+++ b/gitops/kcp/registration/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - clusterrole.yaml
+  - clusterrolebinding.yaml

--- a/gitops/sre/.tekton/kcp-registration.yaml
+++ b/gitops/sre/.tekton/kcp-registration.yaml
@@ -46,7 +46,7 @@ spec:
               image: ghcr.io/openshift-pipelines/kcp-registrar:main
               workingDir: $(workspaces.source.path)
               env:
-                - name: DATA_DIR
+                - name: WORKSPACE_DIR
                   value: $(workspaces.source.path)
                 - name: KCP_ORG
                   value: "pipelines-service"

--- a/gitops/sre/environment/kcp/kustomization.yaml
+++ b/gitops/sre/environment/kcp/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - github.com/Roming22/pipelines-service/gitops/kcp/registration?ref=docs

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -20,16 +20,81 @@ set -o pipefail
 
 usage() {
 
-    printf "Usage: KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" KCP_SYNC_TAG="release-0.5" DATA_DIR="/workspace" ./register.sh\n\n"
+    printf "
+Usage:
+    %s [options]
 
-    # Parameters
-    printf "The following parameters need to be passed to the script:\n"
-    printf "KCP_ORG: the organization for which the workload clusters need to be registered, i.e.: root:pipelines-service\n"
-    printf "KCP_WORKSPACE: the name of the workspace where the workload clusters get registered (created if it does not exist), i.e: compute\n"
-    printf "KCP_SYNC_TAG: the tag of the kcp syncer image to use (preset in the container image at build time and leveraged by the PipelineRun)\n"
-    printf "DATA_DIR: the location of the cluster files\n"
-    printf "          a single file with extension kubeconfig is expected in the subdirectory: credentials/kubeconfig/kcp\n"
-    printf "          kubeconfig files for compute clusters are expected in the subdirectory: credentials/kubeconfig/compute \n\n"
+Deploy Pipelines Service on the clusters as per the configuration in WORKSPACE_DIR.
+
+Mandatory arguments:
+    --kcp-org KCP_ORG
+        Organization for which the workload clusters need to be registered.
+        Example: 'root:pipelines-service'.
+        Can be set through \$KCP_ORG.
+    --kcp-workspace KCP_WORKSPACE
+        Name of the workspace where the workload clusters get registered (created if it
+        does not exist).
+        Example: 'compute'.
+        Can be set through \$KCP_WORKSPACE.
+    --kcp-sync-tag KCP_SYNC_TAG
+        Tag of the kcp syncer image to use (preset in the container image at build time
+        and leveraged by the PipelineRun).
+        Example: 'v0.6.0-alpha0'
+        Can be set through \$KCP_SYNC_TAG.
+
+Optional arguments:
+    -w, --workspace-dir WORKSPACE_DIR
+        Location of the cluster files related to the environment.
+        A single file with extension kubeconfig is expected in the subdirectory: credentials/kubeconfig/kcp
+        Kubeconfig files for compute clusters are expected in the subdirectory: credentials/kubeconfig/compute
+        Default: \$WORKSPACE_DIR or current directory if the environment
+        variable is unset.
+    -d, --debug
+        Activate tracing/debug mode.
+    -h, --help
+        Display this message.
+
+Example:
+    KCP_SYNC_TAG='release-0.6' %s --kcp-org 'root:my_org' --kcp-workspace 'my_workspace' --workspace_dir /path/to/my_dir
+" "${0##*/}" "${0##*/}" >&2
+}
+
+parse_args() {
+    WORKSPACE_DIR="${WORKSPACE_DIR:-$PWD}"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --kcp-org)
+            shift
+            KCP_ORG="$1"
+            ;;
+        --kcp-workspace)
+            shift
+            KCP_WORKSPACE="$1"
+            ;;
+        --kcp-sync-tag)
+            shift
+            KCP_SYNC_TAG="$1"
+            ;;
+        -w | --workspace-dir)
+            shift
+            WORKSPACE_DIR="$1"
+            ;;
+        -d | --debug)
+            set -x
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+        esac
+        shift
+    done
 }
 
 exit_error() {
@@ -54,15 +119,17 @@ prechecks() {
         exit_error "KCP_SYNC_TAG not set\n\n"
     fi
 
-    DATA_DIR=${DATA_DIR:-}
-    if [[ -z "${DATA_DIR}" ]]; then
-        exit_error "DATA_DIR not set\n\n"
+    WORKSPACE_DIR=${WORKSPACE_DIR:-}
+    if [[ -z "${WORKSPACE_DIR}" ]]; then
+        exit_error "WORKSPACE_DIR not set\n\n"
     fi
+
+    WORKSPACE_DIR="$(cd "$WORKSPACE_DIR" >/dev/null && pwd)" || exit_error "WORKSPACE_DIR '$WORKSPACE_DIR' cannot be accessed\n\n"
 }
 
 # populate kcp_kcfg with the location of the kubeconfig for connecting to kcp
 kcp_kubeconfig() {
-    kubeconfig_dir="$DATA_DIR/credentials/kubeconfig"
+    kubeconfig_dir="$WORKSPACE_DIR/credentials/kubeconfig"
     if files=($(ls "$kubeconfig_dir/kcp/"*.kubeconfig 2>/dev/null)); then
         if [ ${#files[@]} -ne 1 ]; then
             exit_error "A single kubeconfig file is expected at $kubeconfig_dir/kcp\n\n"
@@ -71,7 +138,7 @@ kcp_kubeconfig() {
         exit_error "A single kubeconfig file is expected at $kubeconfig_dir/kcp\n\n"
     fi
     tmp_dir=$(mktemp -d)
-    cp -rf "$DATA_DIR/credentials" "$tmp_dir"
+    cp -rf "$WORKSPACE_DIR/credentials" "$tmp_dir"
     kubeconfig_dir="$tmp_dir/credentials/kubeconfig"
     kcp_kcfg="$(ls "$kubeconfig_dir/kcp/"*.kubeconfig)"
 }
@@ -90,7 +157,8 @@ get_clusters() {
         for sub in "${subs[@]}"; do
             context=$(echo -n ${sub} | cut -d ',' -f 1)
             cluster=$(echo -n ${sub} | cut -d ',' -f 2 | cut -d ':' -f 1)
-            if ! (echo "${clusters[@]}" | grep "${cluster}"); then
+            if ! (echo "${clusters[@]}" | grep -q "${cluster}") \
+                && (find "$WORKSPACE_DIR/environment/compute" -type d -name "${cluster}" | grep -q "${cluster}" >/dev/null); then
                 clusters+=(${cluster})
                 contexts+=(${context})
                 kubeconfigs+=(${kubeconfig})
@@ -122,31 +190,48 @@ register() {
     existing_clusters=$(KUBECONFIG=${kcp_kcfg} kubectl get synctargets -o name)
 
     for i in "${!clusters[@]}"; do
-        printf "Processing cluster %s\n" "${clusters[$i]}"
+        printf "Processing cluster %s (%s/%s)\n" "${clusters[$i]}" "$((i+1))" "${#clusters[@]}"
         if echo "${existing_clusters}" | grep "${clusters[$i]}"; then
             printf "Cluster already registered\n"
         else
             printf "Registering cluster\n"
             syncer_manifest="/tmp/syncer-${clusters[$i]}.yaml"
-            KUBECONFIG=${kcp_kcfg} kubectl kcp workload sync "${clusters[$i]}" \
-                --syncer-image ghcr.io/kcp-dev/kcp/syncer:$KCP_SYNC_TAG \
+            KUBECONFIG="${kcp_kcfg}" kubectl kcp workload sync "${clusters[$i]}" \
+                --syncer-image "ghcr.io/kcp-dev/kcp/syncer:$KCP_SYNC_TAG" \
                 --resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io \
                 --output-file "$syncer_manifest"
-            KUBECONFIG=${DATA_DIR}/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply --context ${contexts[$i]} -f "$syncer_manifest"
+            KUBECONFIG="${WORKSPACE_DIR}/credentials/kubeconfig/compute/${kubeconfigs[$i]}" kubectl apply \
+                --context "${contexts[$i]}" -f "$syncer_manifest"
         fi
     done
 }
 
-prechecks
-kcp_kubeconfig
-if [[ "$(KUBECONFIG=${kcp_kcfg} kubectl kcp workspace current | cut -d\" -f2)" == "$KCP_ORG:$KCP_WORKSPACE" ]]; then
-    printf "Workspace: %s" "$KCP_ORG:$KCP_WORKSPACE"
-else
-    printf "Switching to organization %s\n" "${KCP_ORG}"
-    switch_org
-    printf "Switching to workspace %s\n" "${KCP_WORKSPACE}"
-    switch_ws
+configure_synctarget_ws() {
+    manifests_source="$WORKSPACE_DIR/environment/kcp"
+    if [[ -d "$manifests_source" ]]; then
+        printf "Configuring KCP workspace\n"
+        KUBECONFIG=${kcp_kcfg} kubectl apply -k "$manifests_source"
+    fi
+}
+
+main() {
+    parse_args "$@"
+    prechecks
+    kcp_kubeconfig
+    if [[ "$(KUBECONFIG=${kcp_kcfg} kubectl kcp workspace current | cut -d\" -f2)" == "$KCP_ORG:$KCP_WORKSPACE" ]]; then
+        printf "Workspace: %s\n" "$KCP_ORG:$KCP_WORKSPACE"
+    else
+        printf "Switching to organization %s\n" "${KCP_ORG}"
+        switch_org
+        printf "Switching to workspace %s\n" "${KCP_WORKSPACE}"
+        switch_ws
+    fi
+    get_clusters
+    printf "Registering clusters to kcp\n"
+    register
+    configure_synctarget_ws
+}
+
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+    main "$@"
 fi
-get_clusters
-printf "Registering clusters to kcp\n"
-register


### PR DESCRIPTION
The process to bind to an APIExport now requires the right RBAC to be
granted to the user(s).

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>