### PR TITLE
feature: Install rekor when using ckcp

### DIFF
--- a/ckcp/rekor/openshift/kustomization.yaml
+++ b/ckcp/rekor/openshift/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rekor.yaml

--- a/ckcp/rekor/openshift/rekor.yaml
+++ b/ckcp/rekor/openshift/rekor.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rekor
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  source:
+    path: helm-charts/rekor
+    repoURL: 'https://github.com/sigstore/sigstore-helm-operator'
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |-
+        server:
+          ingress:
+            hostname: rekor-server.${domain}
+            annotations:
+              route.openshift.io/termination: "edge"
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Rekor is required to store the data for tekton-chains.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>

The content of this PR will be required when we'll want to deploy tekton-chains.