### PR TITLE
Added NetworkPolicy resource to the kcp-syncer

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -18,6 +18,7 @@ CR_TO_SYNC=(
             pipelineresources.tekton.dev
             runs.tekton.dev
             tasks.tekton.dev
+            networkpolicies.networking.k8s.io
           )
 
 usage() {

--- a/images/kcp-registrar/register.sh
+++ b/images/kcp-registrar/register.sh
@@ -130,7 +130,7 @@ register() {
             syncer_manifest="/tmp/syncer-${clusters[$i]}.yaml"
             KUBECONFIG=${kcp_kcfg} kubectl kcp workload sync "${clusters[$i]}" \
                 --syncer-image ghcr.io/kcp-dev/kcp/syncer:$KCP_SYNC_TAG \
-                --resources deployments.apps,services,ingresses.networking.k8s.io,conditions.tekton.dev,pipelines.tekton.dev,pipelineruns.tekton.dev,pipelineresources.tekton.dev,tasks.tekton.dev,runs.tekton.dev \
+                --resources deployments.apps,services,ingresses.networking.k8s.io,conditions.tekton.dev,pipelines.tekton.dev,pipelineruns.tekton.dev,pipelineresources.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io \
                 >"$syncer_manifest"
             KUBECONFIG=${DATA_DIR}/credentials/kubeconfig/compute/${kubeconfigs[$i]} kubectl apply --context ${contexts[$i]} -f "$syncer_manifest"
         fi


### PR DESCRIPTION
This is to be able to sync *networkpolicies* between kcp-workspaces and the computes.