### PR TITLE
PLNSRVCE-478 : Migration: openshift-pipelines

### DIFF
--- a/gitops/argocd/tektoncd/tekton-config.yaml
+++ b/gitops/argocd/tektoncd/tekton-config.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   profile: all
   targetNamespace: openshift-pipelines
+  pipeline:
+    enable-tekton-oci-bundles: true
   pruner:
     resources:
       - taskrun


### PR DESCRIPTION
- This PR is about the migration of [this](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/build/openshift-pipelines/) as part of kcp transition Epic.
- We are installing and managing OpenShift Pipelines via the operator using GitOps (ArgoCD). Hence, no changes with the installation itself.
- Regarding the config, all the other parameters are either not necessary or available by default. Have added support for oci-bundles in this PR.
- Pipelines-as-Code will be taken up in a separate story/PR.
