### PR TITLE
Fixed issue with --dry-run option

### DIFF
--- a/ckcp/openshift_dev_setup.sh
+++ b/ckcp/openshift_dev_setup.sh
@@ -190,7 +190,7 @@ install_cert_manager() {
   # perform a dry-run create of a cert-manager
   # Certificate resource in order to verify that CRDs are installed and all the
   # required webhooks are reachable by the K8S API server.
-  until kubectl create -f $CKCP_DIR/openshift/base/certs.yaml --dry-run >/dev/null 2>&1; do
+  until kubectl create -f $CKCP_DIR/openshift/base/certs.yaml --dry-run=client >/dev/null 2>&1; do
     echo -n "."
     sleep 5
   done


### PR DESCRIPTION
with k8s 1.24, --dry-run must be used with a value or either client or server. It throws this error otherwise:

```
[bnr@bnr pipelines-service]$ kubectl create -f /home/bnr/workspace/pipelines-service/ckcp/openshift/base/certs.yaml --dry-run
error: --dry-run flag without a value was specified. A value must be set: "none", "server", or "client".
```
