### PR TITLE
fixed the behavior of producing syncer namespace

### DIFF
--- a/docs/kcp-registration.md
+++ b/docs/kcp-registration.md
@@ -19,6 +19,9 @@ KCP_ORG="root:pipelines-service" KCP_WORKSPACE="compute" KCP_SYNC_TAG="release-0
 | KCP_SYNC_TAG | the tag of the kcp syncer image to use (preset in the container image at build time and leveraged by the PipelineRun)|
 | WORKSPACE_DIR | specifies the location of the cluster files<br> - a single file with extension kubeconfig is expected in the subdirectory: `gitops/credentials/kubeconfig/kcp`<br> - kubeconfig files for compute clusters are expected in the subdirectory: `gitops/credentials/kubeconfig/compute`|
 
+**Note:**
+Namespace names are limited to [63 characters](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). SyncTarget names are used as part of the name of the syncer namespace on the target cluster. When the length of the cluster name is less or equal to 43 characters it is used unchanged to populate the SyncTarget name. Otherwise a hash is generated and used as SyncTarget name. To keep a human friendly SyncTarget name, edit the kubeconfig and set the desired cluster name with less than 43 characters.
+
 ## Authentication
 
 The authentication to kcp and the workload clusters is done through the provided kubeconfig files.


### PR DESCRIPTION
**Changes:**

To avoid the error that Syncer namespace is greater than 63, changed the behavior of producing Syncer namespace. 

- use cluster name if <= 43 chars
- use hash otherwise 