### PR TITLE
Add the find utility to the image used for kcp registration 

### DIFF
--- a/images/kcp-registrar/Dockerfile
+++ b/images/kcp-registrar/Dockerfile
@@ -28,6 +28,7 @@ LABEL build-date= \
       vendor="Pipelines Service" \
       version="0.1"
 WORKDIR /
+RUN microdnf install findutils
 ARG KCP_BRANCH
 ENV KCP_SYNC_TAG=${KCP_BRANCH}
 ENV HOME /tmp/home


### PR DESCRIPTION
This [commit](https://github.com/openshift-pipelines/pipelines-service/commit/25695419e862bd0068c47f41c446130b83cc2474#diff-010d75c07c9fda576ad68d1bf93347cf3ded384b058db9926fcd2e52ceafb308R161) added its use in the script

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>