### PR TITLE
update script for starting kcp locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ By default, Argo CD is installed on both clusters. It is possible to deactivate 
 
 ## kcp cluster
 
-[./local/kcp/start.sh](./local/kcp/start.sh) will set up a kcp cluster with ingress controller and envoy.
+[./local/kcp/start.sh](./local/kcp/start.sh) will set up a kcp cluster.
 
 The script can be customized by setting the following optional environment variables:
 

--- a/local/kcp/start.sh
+++ b/local/kcp/start.sh
@@ -117,15 +117,14 @@ PARAMS="${PARAMS:-}"
 if [[ -z "${PARAMS}" ]]; then
   PARAMS=(
     --token-auth-file "${PARENT_PATH}/kcp-tokens"
-    --discovery-poll-interval 3s
     --profiler-address localhost:6060
     -v 2
   )
 fi
 
 kcp-start
-ingress-ctrler-start
-envoy-start
+# ingress-ctrler-start
+# envoy-start
 create-org
 
 touch "${TMP_DIR}/servers-ready"


### PR DESCRIPTION
- remove flag `--discovery-poll-interval`, which is not available anymore in the latest 0.6 release
- do not start ingress components that are not compatible anymore (to be replaced by glbc when ready)

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>