### PR TITLE
PLNSRVCE-530: Make changes in the repo to move images from ghcr.io to quay.io

### DIFF
--- a/.github/workflows/access-setup-image.yaml
+++ b/.github/workflows/access-setup-image.yaml
@@ -1,13 +1,13 @@
-name: Build and Publish kcp-registrar Image
+name: Build and Publish cluster-setup Image
 
 on:
   push:
     branches:
       - main
     paths:
-      - "images/kcp-registrar/**"
+      - "images/access-setup/**"
   workflow_dispatch:
-  
+
 jobs:
   build-push:
 
@@ -26,17 +26,15 @@ jobs:
         run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
 
       # Build and push a kcp-registrar image, tagged with latest and the commit SHA.
-      - name: Build kcp-registrar Image
+      - name: Build access-setup Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: kcp-registrar
-          context: ./images/kcp-registrar
+          image: access-setup
+          context: ./images/access-setup
           tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
           containerfiles: |
-            ./images/kcp-registrar/Dockerfile
-          build-args: |
-            KCP_BRANCH=release-0.6
+            ./images/access-setup/Dockerfile
 
       - name: Push to quay.io
         id: push-to-quay

--- a/.github/workflows/argocd-registrar-image.yaml
+++ b/.github/workflows/argocd-registrar-image.yaml
@@ -36,12 +36,15 @@ jobs:
           containerfiles: |
             ./exploration/argocd-external/images/argocd-registrar/Dockerfile
 
-      - name: Push to ghcr.io
-        id: push-to-ghcr
+      - name: Push to quay.io
+        id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
-          registry: ghcr.io/${{ github.repository_owner }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/cluster-setup-image.yaml
+++ b/.github/workflows/cluster-setup-image.yaml
@@ -36,12 +36,15 @@ jobs:
           containerfiles: |
             ./images/cluster-setup/Dockerfile
 
-      - name: Push to ghcr.io
-        id: push-to-ghcr
+      - name: Push to quay.io
+        id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
-          registry: ghcr.io/${{ github.repository_owner }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/gateway-deployment-image.yaml
+++ b/.github/workflows/gateway-deployment-image.yaml
@@ -36,12 +36,15 @@ jobs:
           containerfiles: |
             ./images/gateway-deployment/Dockerfile
 
-      - name: Push to ghcr.io
-        id: push-to-ghcr
+      - name: Push to quay.io
+        id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
-          registry: ghcr.io/${{ github.repository_owner }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/shellcheck-image.yaml
+++ b/.github/workflows/shellcheck-image.yaml
@@ -36,12 +36,15 @@ jobs:
           containerfiles: |
             ./test/images/shellcheck/Dockerfile
 
-      - name: Push to ghcr.io
-        id: push-to-ghcr
+      - name: Push to quay.io
+        id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
-          registry: ghcr.io/${{ github.repository_owner }}/test
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: quay.io/redhat-pipeline-service
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.tekton/shellcheck-yaml-lint-pipeline.yaml
+++ b/.tekton/shellcheck-yaml-lint-pipeline.yaml
@@ -41,7 +41,7 @@ spec:
         taskSpec:
           steps:
             - name: run-shellcheck
-              image: ghcr.io/openshift-pipelines/test/shellcheck:main
+              image: quay.io/redhat-pipeline-service/shellcheck:main
               script: |
                 #!/usr/bin/env bash
                 find $(workspaces.source.path) -name "*.sh" -exec  shellcheck --severity=warning  {} +

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,7 +59,7 @@ The script will output the location of the kubeconfig file that can be used to i
 Here is an example for running the registration image in a development environment:
 
 ```bash
-podman run --env KCP_ORG='root:pipelines-service' --env KCP_WORKSPACE='compute' --env WORKSPACE_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace ghcr.io/openshift-pipelines/kcp-registrar:main
+podman run --env KCP_ORG='root:pipelines-service' --env KCP_WORKSPACE='compute' --env WORKSPACE_DIR='/workspace' --privileged --volume /home/myusername/plnsvc:/workspace quay.io/redhat-pipeline-service/kcp-registrar:main
 ```
 
 Make sure that iptables/firewalld is not preventing the communication (tcp initiated from the kind clusters) between the containers running on the kind network and the kcp process on the host.

--- a/exploration/argocd-external/gitops/pac/.tekton/argo-registration.yaml
+++ b/exploration/argocd-external/gitops/pac/.tekton/argo-registration.yaml
@@ -43,7 +43,7 @@ spec:
             - name: source
           steps:
             - name: register-to-argo
-              image: ghcr.io/openshift-pipelines/argocd-registrar:main
+              image: quay.io/redhat-pipeline-service/argocd-registrar:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: ARGO_URL

--- a/gitops/sre/.tekton/cluster-setup.yaml
+++ b/gitops/sre/.tekton/cluster-setup.yaml
@@ -43,7 +43,7 @@ spec:
             - name: source
           steps:
             - name: cluster-setup
-              image: ghcr.io/openshift-pipelines/cluster-setup:main
+              image: quay.io/redhat-pipeline-service/cluster-setup:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: WORKSPACE_DIR

--- a/gitops/sre/.tekton/gateway-deployment.yaml
+++ b/gitops/sre/.tekton/gateway-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: source
           steps:
             - name: gateway-deployment
-              image: ghcr.io/openshift-pipelines/gateway-deployment:main
+              image: quay.io/redhat-pipeline-service/gateway-deployment:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: DATA_DIR

--- a/gitops/sre/.tekton/kcp-registration.yaml
+++ b/gitops/sre/.tekton/kcp-registration.yaml
@@ -43,7 +43,7 @@ spec:
             - name: source
           steps:
             - name: register-to-kcp
-              image: ghcr.io/openshift-pipelines/kcp-registrar:main
+              image: quay.io/redhat-pipeline-service/kcp-registrar:main
               workingDir: $(workspaces.source.path)
               env:
                 - name: WORKSPACE_DIR

--- a/images/access-setup/README.md
+++ b/images/access-setup/README.md
@@ -8,7 +8,7 @@ responsible for installing/registering all the required resources.
 
 This action needs to be performed only once in the lifetime of the resource
 being initialized. If the resource creation is automated, the initialization
-can be done using the ` ghcr.io/openshift-pipelines/access-setup` image instead of
+can be done using the `quay.io/redhat-pipeline-service/access-setup:main` image instead of
 checking out the repository and running the script.
 
 ## Definitions


### PR DESCRIPTION
- Created a new organization in quay.io called redhat-pipeline-service
- Created repositories in quay.io in order to upload respective images
- Created a robot account in order to grant access to GitHub actions to upload images to quay.io
- Updated references from ghcr.io to quay.io throughout the repo - both in GitHub actions and PipelineRuns where it was being used
- Added access-setup workflow.
- Tested it on my repo to verify its working fine (similar steps were followed on my quay account and github repo)