### PR TITLE
Fix minor issues in local install scripts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,9 +9,11 @@ We have therefore two scripts to get them running on your local machine with min
 
 Prerequisites:
 
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [kind](https://github.com/kubernetes-sigs/kind)
 - a container engine: [podman](https://podman.io/) or [docker](https://docs.docker.com/engine/)
 - [git](https://git-scm.com/)
+- [jq](https://stedolan.github.io/jq/)
 
 ## Workload clusters with kind
 
@@ -43,7 +45,9 @@ The script can be customized by setting the following optional environment varia
 | KCP_BRANCH | the branch to use. Mind that the script will do a git checkout, to a default release if the branch is not specified |
 | PARAMS | the parameters to start kcp with |
 
-The script will output the location of the kubeconfig file that can be used to interact with the kcp API.
+The script will output:
+	- the location of the kubeconfig file that can be used to interact with the kcp API.
+	- the location of the kubectl kcp plugin which provides KCP specific sub-command for kubectl
 
 ```console
 ./local/kcp/start.sh

--- a/local/kind/setup.sh
+++ b/local/kind/setup.sh
@@ -23,6 +23,14 @@ prechecks () {
         printf "Kind could not be found\n"
         exit 1
     fi
+    if ! command -v kubectl &> /dev/null; then
+        printf "kubectl could not be found\n"
+        exit 1
+    fi
+    if ! command -v jq &> /dev/null; then
+        printf "jq could not be found\n"
+        exit 1
+    fi
 
     if [[ "${ALLOW_ROOTLESS}" == "true" ]]; then
         printf "Rootless mode enabled\n"

--- a/local/utils.sh
+++ b/local/utils.sh
@@ -19,9 +19,17 @@ wait_command() {
   local wait_seconds="${1:-40}"; shift # 40 seconds as default timeout
 
   until [[ $((wait_seconds--)) -eq 0 ]] || eval "$command &> /dev/null" ; do sleep 1; done
+
+  ((++wait_seconds))
 }
 
 cleanup() {
+    local ret="$?"
+    if [[ $ret -eq 0 ]] || [[ $ret -eq 130 ]];then
+      printf "\nTerminating...\n"
+    else
+      printf "\nExit on failure...\n"
+    fi
     if [[ "${#KCP_PIDS[@]}" -gt 0 ]]; then
       printf "\nCleaning up processes %s\n" "${KCP_PIDS[*]}"
       kill "${KCP_PIDS[@]}"


### PR DESCRIPTION
- Add kubectl and jq in prechecks
- Add information about exit status: normal exit(including ctrl-C) vs failure
- Fix wait_command: now program exits if command is not ready and
  timeout expires
- Fix kubectl-kcp plugin path