### PR TITLE
Fix referenced github url 

### DIFF
--- a/gitops/sre/environment/kcp/kustomization.yaml
+++ b/gitops/sre/environment/kcp/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - github.com/Roming22/pipelines-service/gitops/kcp/registration?ref=docs
+  - github.com/openshift-pipelines/pipelines-service/gitops/kcp/registration?ref=main


### PR DESCRIPTION
Fixed referenced github url in `./gitops/sre/environment/kcp/kustomization.yaml` to point to `openshift-pipelines/pipelines-service`

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>